### PR TITLE
Add search benchmarks survey for Part 2 evaluation design

### DIFF
--- a/data/index.md
+++ b/data/index.md
@@ -62,3 +62,11 @@ Data collection status for Part 1.
 ---
 
 **Total**: 22 tools | **Completed**: 5/22
+
+---
+
+## Research Documents
+
+| Document | File | Status |
+|----------|------|--------|
+| Search Benchmarks Survey | [search-benchmarks.md](../docs/research/search-benchmarks.md) | Complete (medium confidence) |

--- a/data/index.md
+++ b/data/index.md
@@ -6,11 +6,11 @@ Data collection status for Part 1.
 
 | Tool | File | Status |
 |------|------|--------|
-| Tavily | [tavily.md](tools/search-apis/tavily.md) | Pending |
-| Exa | [exa.md](tools/search-apis/exa.md) | Pending |
-| Perplexity Sonar | [perplexity-sonar.md](tools/search-apis/perplexity-sonar.md) | Pending |
-| SerpAPI | [serpapi.md](tools/search-apis/serpapi.md) | Pending |
-| Brave Search | [brave-search.md](tools/search-apis/brave-search.md) | Pending |
+| Tavily | [tavily.md](tools/search-apis/tavily.md) | Complete (high confidence) |
+| Exa | [exa.md](tools/search-apis/exa.md) | Complete (medium-high confidence) |
+| Perplexity Sonar | [perplexity-sonar.md](tools/search-apis/perplexity-sonar.md) | Complete (medium confidence) |
+| SerpAPI | [serpapi.md](tools/search-apis/serpapi.md) | Complete (medium confidence) |
+| Brave Search | [brave-search.md](tools/search-apis/brave-search.md) | Complete (high confidence) |
 
 ## Scraping & Extraction
 
@@ -61,4 +61,4 @@ Data collection status for Part 1.
 
 ---
 
-**Total**: 22 tools | **Completed**: 0/22
+**Total**: 22 tools | **Completed**: 5/22

--- a/data/tools/search-apis/brave-search.md
+++ b/data/tools/search-apis/brave-search.md
@@ -1,0 +1,348 @@
+# Brave Search API
+
+<!--
+COLLECTION METADATA
+==================
+Collected: 2026-03-01
+Collector: claude-opus-4-6
+Session: agent-search-landscape data collection
+GitHub Issue: N/A
+Collection Method: WebSearch with multi-source cross-referencing
+Last Verified: 2026-03-01
+Confidence: high — multiple official sources cross-referenced, recent pricing change verified across sources
+-->
+
+## Identity & Basics
+
+| Field | Value | Source |
+|-------|-------|--------|
+| Organization | Brave Software, Inc. (founded 2015 by Brendan Eich & Brian Bondy) | <!-- https://en.wikipedia.org/wiki/Brave_(web_browser) --> |
+| Website | https://brave.com/search/api/ | <!-- https://brave.com/search/api/ --> |
+| License | Proprietary commercial API; terms at api-dashboard.search.brave.com/terms-of-service. Limited, non-exclusive, non-transferable license. Storage/caching of results prohibited without "Data w/ Storage Rights" plan. AI inference rights included only on Search plan ($5/1k tier). | <!-- https://api-dashboard.search.brave.com/terms-of-service --> |
+| Launch Date (Search API) | May 2023 (API specifically). Brave Search itself launched June 2021 (beta), fully released June 2022. | <!-- https://brave.com/blog/search-api-launch/, https://en.wikipedia.org/wiki/Brave_Search --> |
+| GitHub (Official MCP Server) | https://github.com/brave/brave-search-mcp-server | <!-- https://github.com/brave/brave-search-mcp-server --> |
+| GitHub Stars (MCP Server) | ~663 stars | <!-- as of 2026-03-01 --> |
+| Community Size | 100M+ Brave browser users worldwide; 32M monthly active Brave Search users; 200K+ developers signed up for the API (as cited in growth blog); 8B+ annualized searches. | <!-- https://brave.com/blog/search-api-growth/ --> |
+
+## Category Placement
+
+- **Primary**: Web Search API
+- **Secondary**: AI Grounding / LLM Context API, Summarization API, Local/Place Search API
+
+## Core Capability
+
+> A commercial REST API providing web, image, news, video, local/place, and LLM-context search results from Brave's independently-crawled index of 40+ billion pages, with privacy-first design (no query logging, optional Zero Data Retention) and AI summarization capabilities.
+
+## API Surface
+
+<!-- Sources: https://api-dashboard.search.brave.com/app/documentation/web-search/get-started, https://brave.com/blog/most-powerful-search-api-for-ai/, https://brave.com/blog/place-search-api/, https://api-dashboard.search.brave.com/documentation/services/spellcheck, https://api-dashboard.search.brave.com/documentation/services/summarizer, https://api-dashboard.search.brave.com/documentation/services/llm-context -->
+
+### Endpoints / Methods
+
+| Endpoint | Purpose | Input | Output |
+|----------|---------|-------|--------|
+| `GET /res/v1/web/search` | Web search — returns ranked web results with snippets, FAQ, infoboxes | Query string `q`, optional params: `country`, `search_lang`, `count`, `offset`, `safesearch`, `freshness`, `goggles_id`, `units`, `extra_snippets` | JSON: `web.results[]` (url, title, description, age, extra_snippets), plus `mixed`, `query`, `discussions`, `faq`, `infobox`, `locations`, `news`, `videos` |
+| `GET /res/v1/llm/context` | LLM Context — pre-extracted page content optimized for RAG/LLM grounding | Query string `q`, similar params to web search | JSON: smart chunks with clean text extraction, markdown conversion, JSON-LD schemas, tables with row-level granularity |
+| `GET /res/v1/images/search` | Image search | Query string `q`, optional `count`, `safesearch`, `country`, `search_lang` | JSON: image results with thumbnail URLs, source page, dimensions |
+| `GET /res/v1/news/search` | News search | Query string `q`, optional `count`, `freshness`, `country` | JSON: news results with title, URL, source, age, thumbnail |
+| `GET /res/v1/videos/search` | Video search | Query string `q`, optional `count`, `country`, `safesearch` | JSON: video results with title, URL, thumbnail, source, duration |
+| `GET /res/v1/places/search` | Place/Local search (announced Feb 2026) — 200M+ POI index | Query string `q` (optional), `lat`/`lng` center point, `radius` (up to 20km / 13 miles) | JSON: places with name, address, coordinates, category, ratings |
+| `GET /res/v1/summarizer/search` | Summarizer search — returns summary key if query is eligible | Uses key from web search response `summarizer.key` | JSON: summarizer metadata and key |
+| `GET /res/v1/summarizer/summary` | Summarizer summary — AI-generated summary from search results | Summarizer key from prior step | JSON: AI summary text with citations |
+| `GET /res/v1/summarizer/summary_streaming` | Streaming summarizer — same as above but SSE streaming | Summarizer key | SSE stream of summary chunks |
+| `GET /res/v1/spellcheck/search` | Spell checking for queries | Query string `q`, `country` | JSON: corrected query with `altered` flag |
+| `GET /res/v1/suggest/search` | Autocomplete/suggest — query completions as user types | Query string `q`, optional `count`, `country`, `rich` | JSON: array of suggested completions |
+
+Note: The Summarizer operates as a two-step workflow. First call web search, which returns a `summarizer.key` if the query is eligible. Then use that key to call the summarizer endpoint. Summarizer requests are not billed separately — only the initial web search request counts.
+
+### Authentication
+
+- **Method**: API key passed via HTTP header `X-Subscription-Token`
+- **Key management**: Via the Brave Search API dashboard at api-dashboard.search.brave.com
+- **Separate keys per plan**: Each subscription (Search, Answers, Spellcheck, Autosuggest) requires its own API key
+- **Example**: `curl -H "X-Subscription-Token: YOUR_API_KEY" "https://api.search.brave.com/res/v1/web/search?q=query"`
+
+### Rate Limits
+
+Per-plan rate limits (as of Feb 2026 restructuring):
+
+| Plan | Burst Limit (req/sec) | Monthly Quota | Notes |
+|------|-----------------------|---------------|-------|
+| Free (legacy, grandfathered) | 1 req/sec | 2,000 queries/month | No longer available for new signups |
+| Search ($5/1k) | Up to 100 req/sec (plan-dependent) | Pay-per-use after $5 credit | $5 free credit/month = ~1,000 queries |
+| Answers ($4/1k + $5/M tokens) | Plan-dependent | Pay-per-use after $5 credit | Same $5 monthly credit |
+| Spellcheck ($5/10k) | Plan-dependent | Pay-per-use after $5 credit | |
+| Autosuggest ($5/10k) | Plan-dependent | Pay-per-use after $5 credit | |
+| Enterprise | Custom (up to 100 req/sec) | Custom | Contact sales |
+
+Rate limit response headers:
+- `X-RateLimit-Limit` — max requests allowed
+- `X-RateLimit-Remaining` — requests remaining in window
+- `X-RateLimit-Reset` — time when limit resets
+- `X-RateLimit-Policy` — rate limit policy details
+
+Only successful (non-error) responses are counted against quota and billed.
+
+### Input/Output Formats
+
+- **Input**: HTTP GET with URL query parameters. Query string `q` is required for all search endpoints.
+- **Output**: JSON responses. Key fields include `type`, `query`, `web.results[]`, `news.results[]`, `videos.results[]`, `locations.results[]`, `mixed.main[]` (for blended result ordering).
+- **Result fields** (web): `url`, `title`, `description`, `page_age`, `age`, `extra_snippets[]` (up to 5 per result), `deep_results`, `thumbnail`
+- **Summarizer output**: AI-generated text with source citations
+- **LLM Context output**: Pre-extracted page content as structured smart chunks with markdown, JSON-LD, tables
+
+## Pricing
+
+<!-- Sources: https://brave.com/blog/most-powerful-search-api-for-ai/, https://www.implicator.ai/brave-drops-free-search-api-tier-puts-all-developers-on-metered-billing/, https://alternativeto.net/news/2026/2/brave-updates-its-search-api-with-a-new-llm-context-endpoint-for-ai-and-new-pricing/, https://api-dashboard.search.brave.com/app/plans -->
+<!-- Pricing as of: 2026-02-13 (Feb 2026 restructuring) -->
+
+| Tier | Price | Includes |
+|------|-------|----------|
+| Search | $5 per 1,000 requests | Web search, LLM Context, Images, News, Videos, Place Search. AI inference rights included. $5 free credit renews monthly (~1,000 free queries). |
+| Answers | $4 per 1,000 web searches + $5 per 1M tokens (input+output) | AI-researched answers grounded in web results. $5 free credit renews monthly. |
+| Spellcheck | $5 per 10,000 requests | Spelling correction for queries. $5 free credit renews monthly (~10,000 free checks). |
+| Autosuggest | $5 per 10,000 requests | Query autocompletion. $5 free credit renews monthly (~10,000 free suggestions). |
+| Enterprise | Custom pricing | Custom rate limits (up to 100 req/sec), Zero Data Retention (ZDR) option, SOC 2 Type II compliant, dedicated support. |
+| Free (legacy, grandfathered) | $0 | 2,000 queries/month, 1 req/sec. No longer available for new signups as of Feb 2026. |
+
+**Historical context**: From May 2023 to Feb 2026, a free tier offered 2,000 queries/month. In Aug 2025, a "Free AI" tier briefly offered 5,000 queries/month. As of Feb 2026, all plans are metered with $5 monthly credit.
+
+### Per-Unit Economics at Scale
+
+| Volume | Cost per Query | Notes |
+|--------|---------------|-------|
+| Up to ~1,000/month | $0.00 (covered by $5 free credit) | Search plan |
+| 1,001 - 100,000/month | $0.005 per query | $5 per 1,000 requests |
+| 100,000+/month | $0.005 per query (volume discounts via Enterprise) | Contact sales for custom pricing |
+
+- Summarizer requests are free (only the initial web search is billed)
+- Spellcheck/Autosuggest are 10x cheaper at $0.0005 per request
+- Answers plan: $0.004 per search + $0.005 per 1M tokens for AI generation
+- AWS Marketplace: Also available via AWS Marketplace for consolidated billing
+
+## Technical Architecture
+
+<!-- Sources: https://brave.com/blog/search-independence/, https://search.brave.com/help/independence, https://support.brave.app/hc/en-us/articles/4409406835469-What-is-the-Web-Discovery-Project, https://brave.com/blog/ai-summarizer/, https://brave.com/blog/search-api-growth/ -->
+
+### How It Works
+
+**Independent Web Index**: Brave Search operates its own independently crawled web index, unlike most search API alternatives that depend on Google or Bing. As of 2026, the index contains **40+ billion pages** and is refreshed with **100+ million page updates per day**.
+
+**Crawling**: Brave uses a traditional web crawler plus the opt-in Web Discovery Project (WDP) to build and maintain its index.
+
+**Web Discovery Project (WDP)**:
+- Opt-in feature in the Brave browser
+- Consenting users anonymously contribute: visited URLs, search queries, clicks, time-on-page, and page metadata
+- Privacy safeguards: code is open-source for auditing; queries containing emails, phone numbers, or PII are automatically discarded
+- Purpose: guides crawler prioritization, surfaces long-tail content that traditional crawlers might miss
+- Users cannot be identified — cryptographic protocols prevent linking contributions to individuals
+
+**Independence timeline**:
+- June 2021: Launch with ~87% independent results (13% from Bing fallback)
+- Within one year: rose to 93% independent
+- April 2023: achieved **100% independence** — all Bing API calls removed
+- August 2023: Image and video search also cut ties with Bing
+
+**How this differs from Google/Bing-dependent APIs**: Most alternative search APIs (SerpApi, Serper, etc.) scrape or proxy Google/Bing results. Brave controls the entire stack — crawling, indexing, ranking, and serving. This means: (a) no dependency on third-party index availability (critical after Bing API shutdown Aug 2025), (b) ability to enforce Zero Data Retention since queries never leave Brave's infrastructure, (c) independent ranking algorithms not subject to Google/Bing changes.
+
+### Models / Infrastructure
+
+**Ranking**: Machine learning models for result ranking with advanced relevance scoring. Brave has stated they use "advanced machine learning models" for search relevance, with ongoing improvements to natural language query support.
+
+**Summarizer AI**: Composed of **three different LLMs** trained on different tasks:
+1. **QA (Question Answering)** — extracts concrete answers from text snippets
+2. **Summarization** — synthesizes information from multiple web sources
+3. **Language generation** — produces coherent, natural-language output
+
+The Summarizer was fully developed by Brave's Search team, trained to process multiple web sources rather than generating from parametric knowledge alone. Unlike purely generative models, it grounds all output in retrieved web content.
+
+**LLM Context API**: Real-time content extraction that produces "smart chunks" — clean text with markdown conversion, preserved JSON-LD schemas, and tables with row-level granularity. Designed specifically for RAG pipelines and LLM grounding.
+
+**SOC 2 Type II**: Achieved in October 2025 via independent audit by Prescient Security.
+
+**Goggles** (custom re-ranking):
+- Domain-specific language for creating custom result ranking rules
+- Actions: boost, downrank, or filter results based on URL patterns, domains, and criteria
+- Can be provided as: hosted Goggles URL (GitHub/GitLab/Gist), inline specification in request, or mixed
+- Work with both Web Search and News Search endpoints
+- Community-created Goggles can be published and shared
+
+**Rerank** (announced January 2025):
+- Consumer-facing feature built on Goggles technology
+- Users upvote/downvote domains to personalize rankings
+- Changes are per-user, per-device only — no impact on other users
+- Also affects "Answer with AI" feature sourcing
+
+### Self-Host Options
+
+Not available. Brave Search API is a cloud-hosted service only. The index, ranking infrastructure, and Summarizer models are all proprietary and run on Brave's infrastructure.
+
+Available via:
+- Direct API (api.search.brave.com)
+- AWS Marketplace (since July 2025)
+- Amazon Bedrock AgentCore container
+- Snowflake integration (public preview, announced at BUILD London)
+
+## Integration Surface
+
+<!-- Sources: https://brave.com/search/api/tools/, https://github.com/brave/brave-search-mcp-server, https://python.langchain.com/docs/integrations/tools/brave_search/, https://docs.llamaindex.ai/en/stable/api_reference/tools/brave_search/, https://www.npmjs.com/package/brave-search -->
+
+| Integration | Status | Notes |
+|------------|--------|-------|
+| MCP Server (Official) | Available | https://github.com/brave/brave-search-mcp-server — ~663 stars. Part of official modelcontextprotocol/servers repository. Provides web search, local search, image, video, news, and summarization tools. Endorsed by Anthropic. |
+| Python SDK (community) | Available | `brave-search-python-client` — https://pypi.org/project/brave-search-python-client/ — supports Web, Image, News, Video. ~12 GitHub stars. Not official. Install: `pip install brave-search-python-client` |
+| Node/TS SDK (community) | Available | `brave-search` — https://www.npmjs.com/package/brave-search — fully typed Brave Search API wrapper. Third-party, not official. |
+| LangChain | Available (built-in) | `BraveSearchWrapper` in `langchain_community.utilities.brave_search`. Also `BraveSearch` tool in `langchain_community.tools.brave_search.tool`. Env var: `BRAVE_SEARCH_API_KEY`. Methods: `run()` (JSON string), `download_documents()` (list of Documents). |
+| LlamaIndex | Available | `brave_search` tool in LlamaIndex. Documented at docs.llamaindex.ai. Returns list of search results. |
+| CrewAI | Indirect | No dedicated Brave Search tool in CrewAI, but works through MCP server integration or LangChain tools (CrewAI supports LangChain tools). |
+| Anthropic Claude | Primary provider | Brave powers Claude's web search feature. MCP integration highlighted in Claude Desktop and Claude Code demos. |
+| Snowflake | Available (preview) | Integration for Cortex Code and Cortex Agents — agentic web search for enterprise. |
+| AWS Marketplace | Available | Direct subscription and billing via AWS account. Also available as Bedrock AgentCore container. |
+| Go Client (community) | Available | `github.com/cnosuke/go-brave-search` |
+| Pipedream | Available | Pre-built integration for workflow automation. |
+
+**No official SDK**: Brave does not publish an official Python or Node SDK. The API is designed as a simple REST API with HTTP GET requests. Community wrappers exist but are third-party.
+
+## Performance Data
+
+<!-- Sources: https://brave.com/blog/search-api-growth/, https://brave.com/blog/most-powerful-search-api-for-ai/, https://brave.com/blog/soc2/, https://aimultiple.com/agentic-search -->
+
+### Published Benchmarks
+
+| Metric | Value | Source | Notes |
+|--------|-------|--------|-------|
+| SimpleQA F1-score (multi-search + reasoning) | 94.1% | Brave blog (search-api-growth) | Measures factual accuracy and answer completeness |
+| SimpleQA F1-score (single search) | 92.1% | Brave blog (search-api-growth) | Single-query factual accuracy |
+
+### Speed Claims
+
+| Metric | Value | Source |
+|--------|-------|--------|
+| LLM Context API p90 latency | Under 600ms total | Brave blog (most-powerful-search-api-for-ai) |
+| LLM Context overhead (p90) | ~130ms on top of normal search | Brave blog (most-powerful-search-api-for-ai) |
+| Average latency (independent benchmark) | 669ms | AIMultiple agentic search benchmark (2026) |
+| Max throughput | Up to 100 req/sec (Enterprise) | Brave API docs |
+
+### Accuracy / Coverage Claims
+
+| Metric | Value | Source |
+|--------|-------|--------|
+| Index size | 40+ billion pages | Brave official (also stated as 30+ billion in some earlier references; 40B is latest) |
+| Daily index updates | 100+ million page updates/day | Brave official blog |
+| Snippets per result | Up to 5 (with `extra_snippets` param) | Brave API docs |
+| Points of interest (Place Search) | 200+ million | Brave blog (place-search-api) |
+| Search independence | 100% (since April 2023) | Brave blog (search-independence) |
+| Annualized queries | 8+ billion | Brave blog |
+| SOC 2 Type II | Certified (October 2025) | Audited by Prescient Security |
+
+### Privacy Claims
+
+| Claim | Details | Source |
+|-------|---------|--------|
+| No query logging | System-wide policies prevent logging/retention of end-user search queries for unintended purposes | Brave blog (search-api-zero-data-retention) |
+| No user identification | No identifiers collected that can link queries to individuals or devices | Brave privacy notice |
+| Standard retention | Search queries retained max 90 days for billing/troubleshooting | Brave API privacy policy |
+| Zero Data Retention (ZDR) | Enterprise option — no queries stored, logged, or linked. True ZDR possible because Brave controls entire stack. | Brave blog (search-api-zero-data-retention) |
+| Full stack control | Unlike scraper-based APIs, queries never leave Brave infrastructure — no third-party data exposure | Brave blog |
+
+## Limitations
+
+<!-- Sources: https://www.firecrawl.dev/blog/brave-search-api-alternatives, https://community.brave.app/, https://github.com/modelcontextprotocol/servers/issues/ -->
+
+### What It Can't Do
+
+- **No full-page content retrieval**: The Search API returns snippets and metadata, not full page content. The LLM Context API extracts smart chunks but does not return raw HTML/full page. For full page scraping, a separate tool is needed.
+- **No multi-step navigation**: Cannot follow links, fill forms, or perform multi-step web interactions. It is a search API, not a browser automation tool.
+- **No caching/storage rights by default**: Standard terms prohibit storing, caching, or creating databases of search results. Requires "Data w/ Storage Rights" plan tier.
+- **No custom crawl requests**: Cannot request Brave to crawl specific URLs or prioritize specific domains in the index.
+- **No real-time streaming for web search**: Streaming is only available for the Summarizer endpoint, not for standard web/image/news search.
+- **Place Search radius limit**: Maximum 20km (13 miles) from center point.
+
+### Known Failure Modes
+
+- **Long-tail/niche query coverage gaps**: Brave's index is smaller than Google's. For very niche, academic, or obscure queries, results may be thinner or missing entirely.
+- **Non-English coverage**: While improving, coverage for non-English content and regional results may lag behind Google.
+- **Rate limit errors under load**: MCP server users have reported rate limit issues, especially with the legacy free tier's 1 req/sec limit (GitHub issue #596 on modelcontextprotocol/servers).
+- **Summarizer not always available**: The Summarizer only works for eligible queries — not all queries return a summarizer key. Eligibility is determined by Brave's internal logic.
+
+### Documented Issues
+
+- **Feb 2026 pricing change disruption**: Removal of free tier surprised many developers. Legacy free-tier users grandfathered but new users must provide credit card for $5/month credit.
+- **Separate API keys per plan**: Each subscription type (Search, Spellcheck, Autosuggest) requires its own API key, which can be confusing.
+- **MCP server rate limit configurability**: GitHub issue #3127 on modelcontextprotocol/servers requests making rate limits configurable via environment variables, as defaults don't match all tiers.
+- **TOS ambiguity for open-source**: GitHub issue #522 on modelcontextprotocol/servers raised concerns about potential TOS violations when using Brave Search API results in open-source MCP contexts.
+
+## Differentiation
+
+> **Independent index** (not Google/Bing dependent): Brave is one of only three web search indexes at scale in the West (alongside Google and Yandex), and the only one commercially available as a reliable, independent API — especially critical after Bing's API shutdown in August 2025. **Privacy-first**: No query logging, optional Zero Data Retention, full-stack control means queries never leave Brave infrastructure. **AI-native endpoints**: LLM Context API delivers pre-extracted smart chunks optimized for RAG/LLM grounding (not just links), plus a built-in Summarizer powered by three custom LLMs. **Goggles**: Unique custom re-ranking system allowing programmatic control over result ordering via a domain-specific language. **Cost structure**: $5/month free credit, $0.005 per query at scale, with included AI inference rights. **SOC 2 Type II certified** (Oct 2025). **Supplies most top-10 LLMs** with real-time search data, including Claude.
+
+## Raw Notes
+
+- Brave Search was built on technology acquired from Tailcat (open-source search engine by Cliqz GmbH, Germany), acquired in 2021.
+- The Brave browser's Web Discovery Project is a key differentiator for index quality — it crowdsources URL discovery and engagement signals from opt-in browser users, providing long-tail coverage that traditional crawlers miss.
+- Post-Bing API shutdown (Aug 2025), Brave has positioned itself as the de facto alternative for developers who previously used Bing Search API. Google took legal action against SerpApi around the same time, further consolidating Brave's position.
+- The Feb 2026 pricing restructure aligned with the launch of the LLM Context API — Brave is clearly pivoting toward being the search infrastructure layer for AI applications.
+- No official SDK exists — this is by design as the API is intentionally simple (HTTP GET + JSON). Community SDKs exist for Python, Node/TS, and Go.
+- The API Assistant in the Developer Portal is trained to answer API questions and generate code examples.
+- Brave Search MCP server is in the official modelcontextprotocol/servers repo and was highlighted in early Claude Code demos.
+
+## Source Log
+
+<!-- Complete list of all sources consulted for this profile -->
+
+| # | Source | Type | URL | Accessed |
+|---|--------|------|-----|----------|
+| 1 | Brave Search API — official landing page | official-docs | https://brave.com/search/api/ | 2026-03-01 |
+| 2 | Brave Search API Documentation — Get Started | api-reference | https://api-dashboard.search.brave.com/app/documentation/web-search/get-started | 2026-03-01 |
+| 3 | Brave Blog — "Most powerful search API for AI to date" (Feb 2026) | blog-official | https://brave.com/blog/most-powerful-search-api-for-ai/ | 2026-03-01 |
+| 4 | Brave Blog — "Search API shows exponential growth" | blog-official | https://brave.com/blog/search-api-growth/ | 2026-03-01 |
+| 5 | Brave Blog — "Place Search API" (Feb 2026) | blog-official | https://brave.com/blog/place-search-api/ | 2026-03-01 |
+| 6 | Brave Blog — "Search independence" (April 2023) | blog-official | https://brave.com/blog/search-independence/ | 2026-03-01 |
+| 7 | Brave Blog — "Zero Data Retention" | blog-official | https://brave.com/blog/search-api-zero-data-retention/ | 2026-03-01 |
+| 8 | Brave Blog — "SOC 2 Type II attestation" (Oct 2025) | blog-official | https://brave.com/blog/soc2/ | 2026-03-01 |
+| 9 | Brave Blog — "AI Summarizer" | blog-official | https://brave.com/blog/ai-summarizer/ | 2026-03-01 |
+| 10 | Brave Blog — "Search API launch" (May 2023) | blog-official | https://brave.com/blog/search-api-launch/ | 2026-03-01 |
+| 11 | Brave Blog — "Introducing Rerank" (Jan 2025) | blog-official | https://brave.com/blog/search-rerank/ | 2026-03-01 |
+| 12 | Brave Blog — "Snowflake integration" | blog-official | https://brave.com/blog/snowflake/ | 2026-03-01 |
+| 13 | Brave Blog — "AWS Marketplace" (July 2025) | blog-official | https://brave.com/blog/search-api-aws-marketplace/ | 2026-03-01 |
+| 14 | Brave Help Center — Web Discovery Project | official-docs | https://support.brave.app/hc/en-us/articles/4409406835469-What-is-the-Web-Discovery-Project | 2026-03-01 |
+| 15 | Brave Search API — Rate Limiting docs | api-reference | https://api-dashboard.search.brave.com/documentation/guides/rate-limiting | 2026-03-01 |
+| 16 | Brave Search API — Authentication docs | api-reference | https://api-dashboard.search.brave.com/documentation/guides/authentication | 2026-03-01 |
+| 17 | Brave Search API — Goggles docs | api-reference | https://api-dashboard.search.brave.com/documentation/resources/goggles | 2026-03-01 |
+| 18 | Brave Search API — Spellcheck docs | api-reference | https://api-dashboard.search.brave.com/documentation/services/spellcheck | 2026-03-01 |
+| 19 | Brave Search API — Suggest docs | api-reference | https://api-dashboard.search.brave.com/documentation/services/suggest | 2026-03-01 |
+| 20 | Brave Search API — LLM Context docs | api-reference | https://api-dashboard.search.brave.com/documentation/services/llm-context | 2026-03-01 |
+| 21 | Brave Search API — Summarizer docs | api-reference | https://api-dashboard.search.brave.com/documentation/services/summarizer | 2026-03-01 |
+| 22 | Brave Search API — Privacy notice | official-docs | https://api-dashboard.search.brave.com/documentation/resources/privacy-notice | 2026-03-01 |
+| 23 | Brave Search API — Terms of Service | official-docs | https://api-dashboard.search.brave.com/terms-of-service | 2026-03-01 |
+| 24 | Brave Search API — Plans page | official-docs | https://api-dashboard.search.brave.com/app/plans | 2026-03-01 |
+| 25 | Brave Search API — "What sets it apart" guide | official-docs | https://brave.com/search/api/guides/what-sets-brave-search-api-apart/ | 2026-03-01 |
+| 26 | GitHub — brave/brave-search-mcp-server | github-repo | https://github.com/brave/brave-search-mcp-server | 2026-03-01 |
+| 27 | GitHub — brave-search-python-client | github-repo | https://github.com/helmut-hoffer-von-ankershoffen/brave-search-python-client | 2026-03-01 |
+| 28 | npm — brave-search | github-repo | https://www.npmjs.com/package/brave-search | 2026-03-01 |
+| 29 | LangChain — Brave Search integration docs | official-docs | https://python.langchain.com/docs/integrations/tools/brave_search/ | 2026-03-01 |
+| 30 | LlamaIndex — Brave Search tool reference | official-docs | https://docs.llamaindex.ai/en/stable/api_reference/tools/brave_search/ | 2026-03-01 |
+| 31 | Wikipedia — Brave Search | community | https://en.wikipedia.org/wiki/Brave_Search | 2026-03-01 |
+| 32 | Implicator.ai — "Brave Drops Free Search API Tier" | blog-third-party | https://www.implicator.ai/brave-drops-free-search-api-tier-puts-all-developers-on-metered-billing/ | 2026-03-01 |
+| 33 | AlternativeTo — "Brave updates Search API with LLM context endpoint" (Feb 2026) | blog-third-party | https://alternativeto.net/news/2026/2/brave-updates-its-search-api-with-a-new-llm-context-endpoint-for-ai-and-new-pricing/ | 2026-03-01 |
+| 34 | AIMultiple — "Agentic Search 2026: Benchmark 8 Search APIs" | benchmark | https://aimultiple.com/agentic-search | 2026-03-01 |
+| 35 | TechCrunch — "Anthropic using Brave for Claude web search" (March 2025) | news | https://techcrunch.com/2025/03/21/anthropic-appears-to-be-using-brave-to-power-web-searches-for-its-claude-chatbot/ | 2026-03-01 |
+| 36 | GitHub — modelcontextprotocol/servers issue #596 (rate limits) | community | https://github.com/modelcontextprotocol/servers/issues/596 | 2026-03-01 |
+| 37 | GitHub — modelcontextprotocol/servers issue #3127 (configurable rate limits) | community | https://github.com/modelcontextprotocol/servers/issues/3127 | 2026-03-01 |
+| 38 | GitHub — modelcontextprotocol/servers issue #522 (TOS concerns) | community | https://github.com/modelcontextprotocol/servers/issues/522 | 2026-03-01 |
+| 39 | Firecrawl Blog — "Top 5 Brave Search API Alternatives in 2026" | blog-third-party | https://www.firecrawl.dev/blog/brave-search-api-alternatives | 2026-03-01 |
+| 40 | AWS Marketplace — Brave Search API listing | official-docs | https://aws.amazon.com/marketplace/pp/prodview-qjlabherxghtq | 2026-03-01 |
+| 41 | Microsoft Learn — Bing Search API retirement announcement | official-docs | https://learn.microsoft.com/en-us/lifecycle/announcements/bing-search-api-retirement | 2026-03-01 |
+
+<!--
+Source Types:
+  official-docs  -- Official documentation / API reference
+  api-reference  -- Detailed API/SDK documentation
+  github-repo    -- GitHub repository README, code, issues
+  blog-official  -- Official blog post from the tool's org
+  blog-third-party -- Third-party blog, comparison article
+  benchmark      -- Independent benchmark or test results
+  news           -- News article or press release
+  community      -- Forum post, Discord, Stack Overflow
+  inference      -- Derived/inferred from other data (flag for verification)
+-->

--- a/data/tools/search-apis/exa.md
+++ b/data/tools/search-apis/exa.md
@@ -1,0 +1,347 @@
+# Exa
+
+<!--
+COLLECTION METADATA
+==================
+Collected: 2026-03-01
+Collector: claude-opus-4-6
+Session: agent-search-landscape research
+GitHub Issue: N/A
+Collection Method: WebSearch (multiple queries), cross-referenced with official docs URLs, GitHub repos, PyPI, npm
+Last Verified: 2026-03-01
+Confidence: medium — WebFetch unavailable; data gathered via WebSearch summaries cross-referenced across multiple sources. No direct page reads of docs.exa.ai or exa.ai/pricing were possible.
+-->
+
+## Identity & Basics
+
+| Field | Value | Source |
+|-------|-------|--------|
+| Organization | Exa Labs, Inc. | <!-- https://www.ycombinator.com/companies/exa --> |
+| Website | https://exa.ai | <!-- https://exa.ai --> |
+| Former Name | Metaphor (rebranded to Exa early 2024) | <!-- https://cerebralvalley.ai/blog/exa-aims-to-reshape-web-search-4AOjbOWK9sxxXCKdjQG1EK --> |
+| License | Proprietary API service (SDKs are MIT-licensed) | <!-- https://pypi.org/project/exa-py/ ; core search engine is proprietary --> |
+| Founded | 2021 | <!-- https://www.ycombinator.com/companies/exa --> |
+| Y Combinator | S21 batch | <!-- https://www.ycombinator.com/companies/exa --> |
+| Founders | Will Bryk, Jeff Wang (met as Harvard freshmen) | <!-- https://cerebralvalley.ai/blog/exa-aims-to-reshape-web-search-4AOjbOWK9sxxXCKdjQG1EK --> |
+| HQ | San Francisco, CA | <!-- https://www.cbinsights.com/company/metaphor-1 --> |
+| Funding | $85M Series B (Sept 2025) at $700M valuation, led by Benchmark; Lightspeed, Y Combinator, NVentures (NVIDIA) participating. Seed $5M via YC S21. | <!-- https://exa.ai/blog/announcing-series-b ; https://siliconangle.com/2025/09/03/nvidia-backs-85m-round-ai-search-startup-exa/ --> |
+| GitHub Org | https://github.com/exa-labs (73 repos) | <!-- https://github.com/exa-labs --> |
+| GitHub Stars (exa-py) | ~170 | <!-- https://github.com/exa-labs/exa-py as of 2026-03-01 --> |
+| GitHub Stars (exa-js) | ~97 | <!-- https://github.com/exa-labs/exa-js as of 2026-03-01 --> |
+| GitHub Stars (exa-mcp-server) | ~3,700 | <!-- https://github.com/exa-labs/exa-mcp-server as of 2026-03-01 --> |
+| Community Size | Not independently measured; LinkedIn page: "Exa (prev. Metaphor)" | <!-- https://www.linkedin.com/company/exa-ai --> |
+
+## Category Placement
+
+- **Primary**: AI-Native Web Search API
+- **Secondary**: Web Crawler / Content Extraction, Entity Sourcing (Websets)
+
+## Core Capability
+
+> Exa is a web search engine built from scratch for AI agents and LLMs, using neural embeddings rather than keyword matching to retrieve semantically relevant web content, with its own proprietary web index of billions of pages.
+
+## API Surface
+
+<!-- Sources: https://docs.exa.ai/reference/search ; https://docs.exa.ai/llms.txt ; https://data4ai.com/blog/vendor-spotlights/exa-ai-review/ ; https://docs.exa.ai/reference/how-exa-search-works -->
+
+### Endpoints / Methods
+
+| Endpoint | Method | Purpose | Input | Output |
+|----------|--------|---------|-------|--------|
+| `/search` | POST | Semantic or keyword web search | JSON: `query`, `type`, `numResults`, `contents`, `includeDomains`, `excludeDomains`, `startPublishedDate`, `endPublishedDate`, `startCrawlDate`, `endCrawlDate`, `category`, `useAutoprompt` | JSON: `requestId`, `results[]` with `title`, `url`, `publishedDate`, `author`, `id`, `image`, `favicon`, `score`, `text`, `highlights`, `highlightScores`, `summary` |
+| `/findSimilar` | POST | Find pages semantically similar to a given URL | JSON: `url`, `numResults`, `contents`, `includeDomains`, `excludeDomains` | Same result schema as `/search` |
+| `/contents` (getContents) | POST | Retrieve clean parsed content for a list of URLs | JSON: `ids` (list of URLs or Exa IDs), `text`, `highlights`, `summary` | JSON: `results[]` with content fields populated |
+| `/answer` | POST | Direct answers to questions with citations | JSON: `query`, `text` | JSON: answer text with source citations |
+| `/research` | POST | Agentic multi-step research with structured output | JSON: `query`, `outputSchema` (supports text or JSON object) | JSON: structured research results with citations; supports `output_schema` for structured JSON (max nesting depth 2, max 10 properties) |
+| Websets API (`/websets`) | POST/GET | Create, list, preview entity-sourcing jobs | JSON: search criteria, enrichment columns | JSON: webset items with enriched entity data |
+
+### Search Types
+
+| Type | Description | Latency (P50) |
+|------|-------------|---------------|
+| `auto` (default) | Intelligently combines neural and other search methods | Varies |
+| `neural` | Pure embeddings-based semantic search | ~350ms |
+| `keyword` | Google-style keyword/BM25 search | Fast |
+| `fast` | Streamlined neural + reranker models | <350ms |
+| `deep` | Light deep search with query expansion | ~3.5s |
+| `deep-reasoning` | Base deep search | Slower |
+| `deep-max` | Maximum-effort deep search | Slowest |
+| `instant` | Lowest-latency neural search (launched Feb 2026) | 100-200ms (sub-200ms) |
+
+### Content Retrieval Options
+
+| Option | Description |
+|--------|-------------|
+| `text` | Full page text, configurable via `maxCharacters` |
+| `highlights` | AI-extracted relevant excerpts/snippets, configurable via `maxCharacters` |
+| `summary` | AI-generated summary of each result |
+| `livecrawl` | Options: `fallback` (default, use cache first), `preferred` (try fresh, fallback to cache), `always` (always crawl fresh) |
+
+### Authentication
+
+- **Method**: API key via `x-api-key` HTTP header
+- **Key management**: https://dashboard.exa.ai/api-keys
+- **Key creation**: Supports named keys with optional per-key rate limits
+- **Environment variable**: `EXA_API_KEY`
+
+### Rate Limits
+
+- Rate limits are defined as QPS (queries per second) per endpoint
+- Research API uses concurrent task limits (not QPS) due to long-running operations
+- Default rate limits apply to all users; specific values per tier are not publicly documented in detail
+- Higher rate limits available via Enterprise plan (contact hello@exa.ai)
+- Websets concurrency: Starter = 2 concurrent searches, Pro = 10 concurrent searches
+
+### Input/Output Formats
+
+- **Protocol**: REST API over HTTPS
+- **Base URL**: `https://api.exa.ai`
+- **Content-Type**: `application/json`
+- **Date format**: ISO 8601 for temporal filtering
+- **OpenAPI spec**: https://raw.githubusercontent.com/exa-labs/openapi-spec/refs/heads/master/exa-openapi-spec.yaml
+- **Filtering**: `includeDomains`, `excludeDomains`, `category` (e.g., people, company, code), date ranges
+
+## Pricing
+
+<!-- Sources: https://exa.ai/pricing ; https://findmyaitool.io/tool/exa/ ; https://dev.to/ritza/best-serp-api-comparison-2025-serpapi-vs-exa-vs-tavily-vs-scrapingdog-vs-scrapingbee-2jci -->
+<!-- Pricing as of: 2026-03-01 -->
+
+### Search API (Pay-As-You-Go)
+
+| Tier | Price | Includes |
+|------|-------|----------|
+| Free | $0 (one-time $10 credit, no expiration, no CC required) | ~2,000 searches at standard rate |
+| Pay-as-you-go | $5 per 1,000 searches (1-25 results per query) | No monthly commitment |
+| Higher result counts (26-100 results) | ~$0.025 per search | Premium rate for larger result sets |
+
+### Websets Product (Subscription)
+
+| Tier | Price | Credits/mo | Seats | Results per Webset | Enrichment Columns | Concurrent Searches |
+|------|-------|-----------|-------|-------------------|--------------------|---------------------|
+| Starter | $49/mo | 8,000 | 1 | Up to 100 | 10 | 2 |
+| Pro | $449/mo | 100,000 | 10 | Up to 1,000 | 50 | 10 |
+| Enterprise | Custom | Custom | Unlimited | Unlimited | Unlimited | Custom |
+
+Websets credit economy: 10 credits = 1 all-green (fully validated) result in a generated webset.
+
+### Per-Unit Economics at Scale
+
+- Standard search: $0.005 per search (1-25 results)
+- At scale, pricing approaches $0.025 per search for larger result sets
+- Content retrieval (text/highlights/summary) costs are included in the search credit
+- Enterprise volume discounts available upon request
+- AWS Marketplace listing also available for procurement convenience
+
+## Technical Architecture
+
+<!-- Sources: https://exa.ai/blog/how-to-build-nextgen-search ; https://docs.exa.ai/reference/how-exa-search-works ; https://exa.ai/blog/meet-the-exacluster ; https://exa.ai/blog/bm25-optimization ; https://www.marktechpost.com/2026/02/13/exa-ai-introduces-exa-instant-a-sub-200ms-neural-search-engine-designed-to-eliminate-bottlenecks-for-real-time-agentic-workflows/ -->
+
+### How It Works
+
+Exa is fundamentally different from traditional search engines. Instead of preprocessing documents into keyword indices (inverted index / BM25), Exa trains neural transformer models to convert each document into dense vector embeddings. Search queries are also converted into embeddings, and retrieval is performed via nearest-neighbor similarity in embedding space.
+
+**Key architectural concepts:**
+
+1. **Next-Link Prediction**: Exa's core model is trained on a "next-link prediction" task -- given a description of a webpage, predict which URL would follow. This teaches the model to understand the semantic content of web pages.
+
+2. **Hybrid Retrieval**: The production system uses a hybrid approach combining both embedding-based neural search and optimized BM25 keyword search, selecting the best method or combining results depending on the query.
+
+3. **Own Web Index**: Exa crawls and indexes billions of web pages independently (not relying on Google or Bing). The index is updated every minute for real-time freshness.
+
+4. **Multi-Stage Pipeline**: Query -> embedding generation -> approximate nearest neighbor search in vector DB -> neural reranking -> content extraction -> response formatting.
+
+### Models / Infrastructure
+
+- **Embedding models**: Proprietary transformer models trained on web-scale data; uses matryoshka embeddings (multi-resolution) and binary quantization for efficient storage and retrieval
+- **Reranker**: Separate neural reranker model that re-scores candidate results for final ranking
+- **Vector database**: Custom-built in Rust; uses clustering, matryoshka embeddings, binary quantization, and SIMD operations for performance
+- **GPU cluster ("Exacluster")**: 144 H200 GPUs (18 nodes of 8 each) for embedding billions of pages, training rerankers, and serving inference. Plans to expand 5x with Series B funds.
+- **Specialized models**: Fine-tuned retrieval models for specific categories (people search, company search, code search)
+- **BM25 optimization**: Custom-optimized BM25 implementation for the keyword search component
+
+### Self-Host Options
+
+No self-hosting available. Exa is a proprietary cloud API service. The search engine, web index, and models are all hosted by Exa.
+
+## Integration Surface
+
+<!-- Sources: https://docs.exa.ai/reference/exa-mcp ; https://github.com/exa-labs/exa-mcp-server ; https://github.com/exa-labs/exa-py ; https://github.com/exa-labs/exa-js ; https://docs.exa.ai/reference/langchain ; https://docs.exa.ai/reference/llamaindex ; https://docs.exa.ai/reference/crewai ; https://docs.exa.ai/reference/vercel ; https://github.com/exa-labs/ai-sdk -->
+
+| Integration | Status | Package / Install | Notes |
+|------------|--------|-------------------|-------|
+| MCP Server | Official, open-source | `npx exa-mcp-server` or hosted at `https://mcp.exa.ai/mcp` | ~3,700 GitHub stars; supports Claude Desktop, Cursor, VS Code, Zed; tools: web_search, code_search, crawl. Also has `websets-mcp-server` and `exa-knowledge-mcp`. |
+| Python SDK | Official, MIT license | `pip install exa-py` (import as `exa_py`) | Sync + async support; Python >=3.9; ~170 GitHub stars |
+| Node/TS SDK | Official | `npm install exa-js` (import as `exa-js`) | Full TypeScript types; ~97 GitHub stars |
+| LangChain (Python) | Official partner integration | `pip install langchain-exa` | Provides `ExaSearchRetriever` and `ExaSearchResults` tool; supports neural/keyword/auto search types; lives in `langchain-ai/langchain` monorepo under `libs/partners/exa/` |
+| LangChain (JS) | Official | `npm install @langchain/exa` | JavaScript/TypeScript counterpart |
+| LlamaIndex | Official integration | `pip install llama-index-tools-exa` | Provides `ExaToolSpec` with tools: `search`, `retrieve_documents`, `search_and_retrieve_documents`, `find_similar`, `current_date` |
+| CrewAI | Documented integration | Use `exa-py` with `@tool` decorator | Custom tool pattern using Exa Python SDK within CrewAI agents |
+| Vercel AI SDK | Official | `npm install @exalabs/ai-sdk` | `webSearch` tool for Vercel AI SDK; defaults: type=auto, 10 results, 3000 chars |
+| Composio | Third-party | Via Composio platform | Bridges Exa to LangChain, LlamaIndex, CrewAI via Composio toolkits |
+| IBM WatsonX | Documented | Via MCP or direct API | Listed in Exa's integration docs |
+| OpenRouter | Documented | Via MCP or direct API | Listed in Exa's integration docs |
+
+## Performance Data
+
+<!-- Sources: https://exa.ai/versus/tavily ; https://data4ai.com/blog/tool-comparisons/exa-ai-vs-tavily/ ; https://www.humai.blog/ai-search-apis-compared-tavily-vs-exa-vs-perplexity/ ; https://www.marktechpost.com/2026/02/13/exa-ai-introduces-exa-instant-a-sub-200ms-neural-search-engine-designed-to-eliminate-bottlenecks-for-real-time-agentic-workflows/ ; https://exa.ai/blog/people-search-benchmark ; https://exa.ai/blog/company-search-benchmarks -->
+
+### Published Benchmarks
+
+| Benchmark | Exa Score | Tavily Score | Source |
+|-----------|-----------|-------------|--------|
+| WebWalker (complex multi-hop retrieval) | 81% | 71% | Fortune 100 enterprise evaluation (cited on exa.ai/versus/tavily) |
+| MKQA (multilingual queries) | 70% | 63% | Same enterprise evaluation |
+| 500-query real customer workload | 0.648 | 0.343 | Same enterprise evaluation |
+
+**Note**: The 81% vs 71% benchmark comes from Exa's own comparison page (exa.ai/versus/tavily), citing an independent Fortune 100 enterprise evaluation. This is Exa-published data; independent third-party verification of the exact methodology is not publicly available.
+
+### Speed Claims
+
+| Metric | Value | Source |
+|--------|-------|--------|
+| Exa Fast P50 latency | <350ms | docs.exa.ai |
+| Exa Instant P50 latency | 100-200ms (sub-200ms) | exa.ai/blog/exa-instant (Feb 2026) |
+| Exa Deep P50 latency | ~3.5s | docs.exa.ai |
+| Exa p95 latency (enterprise eval) | 1.4-1.7s | exa.ai/versus/tavily |
+| Tavily p95 latency (enterprise eval) | 3.8-4.5s | exa.ai/versus/tavily |
+| Exa Instant claim | "Fastest web search engine in the world, faster than Google search" | exa.ai/blog/exa-instant |
+| Exa Fast claim | "30% faster than the next fastest API" | docs.exa.ai |
+| Exa Instant vs competitors | "Up to 15x faster" | marktechpost.com coverage |
+
+### Accuracy / Coverage Claims
+
+- Web index: "billions of pages" indexed
+- Index freshness: Updated every minute
+- People search: 1B+ public profiles indexed
+- Open benchmarks published for: people search (1,400 queries), company search (800 queries), code search hallucination evaluation
+- Content extraction: Exa 69.2% coverage vs Firecrawl 77.2% in one third-party evaluation (Source: firecrawl.dev/blog/exa-alternatives)
+
+## Limitations
+
+<!-- Sources: https://skywork.ai/skypage/en/Exa-AI-The-Ultimate-Guide-for-Developers-AI-Builders/1972878623855276032 ; https://10web.io/ai-tools/exa/ ; https://data4ai.com/blog/vendor-spotlights/exa-ai-review/ ; https://www.firecrawl.dev/blog/exa-alternatives ; https://docs.exa.ai/websets/faq -->
+
+### What It Can't Do
+
+- **No generation/synthesis**: Exa is retrieval-only. It does not generate text, summarize across multiple documents, or perform reasoning. (The `/answer` and `/research` endpoints provide some synthesis but are separate from core search.)
+- **No self-hosting**: Entirely cloud-hosted; no on-premise or self-hosted option.
+- **No image/video search**: Limited multimodal capabilities; primarily text-based retrieval.
+- **No real-time streaming results**: Results are returned as complete JSON responses.
+
+### Known Failure Modes
+
+- **Niche/low-traffic domains**: Quality-based indexing means obscure or low-traffic sites may not be indexed. Less effective for ultra-niche or low-volume domains.
+- **Overly restrictive Websets queries**: Very narrow searches with too many restrictive criteria may return zero matches.
+- **Raw HTML quality**: Sometimes requires additional processing for clean data extraction from crawled content.
+- **Content extraction coverage gap**: Third-party benchmarks show Firecrawl outperforms Exa on raw extraction coverage (77.2% vs 69.2%).
+
+### Documented Issues
+
+- **Pricing complexity**: Credit-based pricing can be difficult to predict; costs vary based on endpoint used, search type, number of results, and content options.
+- **Documentation maturity**: Documentation described as "still minimal compared to older platforms" by some third-party reviewers (though this may be improving).
+- **Scalability cost**: Massive data volumes can incur significant cost increases.
+- **Websets is not general Q&A**: Websets is designed for entity sourcing, not open-ended question answering.
+
+## Differentiation
+
+> Exa is unique among AI search APIs because it built its own web index and neural search engine from scratch, rather than wrapping Google/Bing APIs. Its "next-link prediction" training approach gives it genuine semantic understanding of queries, not just keyword matching with an LLM layer on top. This architectural ownership -- from crawler to custom Rust vector DB to GPU inference cluster -- enables latency and relevance advantages that wrapper-based APIs cannot replicate.
+
+**Key differentiators:**
+
+1. **Own web index**: Unlike Tavily, SerpAPI, and others that wrap existing search engines, Exa maintains its own index of billions of pages updated every minute.
+
+2. **Neural-native architecture**: Embeddings and transformers are core to the system, not bolted on. The "next-link prediction" training paradigm is architecturally distinct.
+
+3. **Specialized entity search**: Fine-tuned models for people search (1B+ profiles), company search, and code search -- with published open benchmarks for each.
+
+4. **Exa Instant (Feb 2026)**: Sub-200ms neural search, claimed faster than Google search, enabling real-time agentic and voice workflows.
+
+5. **Full-stack ownership**: Custom Rust vector database, 144 H200 GPU cluster, proprietary crawler, embedding models, and reranker -- all built in-house. Enables optimization across the entire stack.
+
+6. **Research API**: Agentic search that autonomously performs multi-step research, reads pages, clusters, and summarizes with structured JSON output schemas.
+
+7. **Websets**: A distinct product for entity sourcing and enrichment (people, companies) that goes beyond search into structured data collection.
+
+## Raw Notes
+
+- Exa was initially building a consumer search engine but pivoted to API-for-AI after ChatGPT launched, realizing companies/agents were the primary users of redesigned search.
+- Peter Fenton (Benchmark) joined the board after Series B.
+- The company has an OpenAPI spec published on GitHub for API consumers.
+- Exa's MCP server is one of the most starred MCP servers in the ecosystem (~3,700 stars), suggesting strong adoption in the Claude/Cursor/AI-coding-assistant ecosystem.
+- `exa-knowledge-mcp` is a separate MCP server that provides access to Exa's own API documentation and best practices within development environments.
+- AWS Marketplace listing available for enterprise procurement.
+- Exa blog posts on technical topics: BM25 optimization, scaling highlights server, Exacluster infrastructure, next-gen search architecture.
+
+## Source Log
+
+<!-- Complete list of all sources consulted for this profile -->
+
+| # | Source | Type | URL | Accessed |
+|---|--------|------|-----|----------|
+| 1 | Exa homepage | official-docs | https://exa.ai | 2026-03-01 |
+| 2 | Exa API docs - Search | api-reference | https://docs.exa.ai/reference/search | 2026-03-01 |
+| 3 | Exa docs - How Search Works | official-docs | https://docs.exa.ai/reference/how-exa-search-works | 2026-03-01 |
+| 4 | Exa docs - Rate Limits | official-docs | https://exa.ai/docs/reference/rate-limits | 2026-03-01 |
+| 5 | Exa Pricing page | official-docs | https://exa.ai/pricing | 2026-03-01 |
+| 6 | Exa llms.txt | official-docs | https://docs.exa.ai/llms.txt | 2026-03-01 |
+| 7 | Exa vs Tavily comparison | official-docs | https://exa.ai/versus/tavily | 2026-03-01 |
+| 8 | Exa blog - API 2.0 | blog-official | https://exa.ai/blog/exa-api-2-0 | 2026-03-01 |
+| 9 | Exa blog - How to build next-gen search | blog-official | https://exa.ai/blog/how-to-build-nextgen-search | 2026-03-01 |
+| 10 | Exa blog - BM25 optimization | blog-official | https://exa.ai/blog/bm25-optimization | 2026-03-01 |
+| 11 | Exa blog - Exacluster | blog-official | https://exa.ai/blog/meet-the-exacluster | 2026-03-01 |
+| 12 | Exa blog - Exa Instant | blog-official | https://exa.ai/blog/exa-instant | 2026-03-01 |
+| 13 | Exa blog - Series B announcement | blog-official | https://exa.ai/blog/announcing-series-b | 2026-03-01 |
+| 14 | Exa blog - People Search Benchmarks | blog-official | https://exa.ai/blog/people-search-benchmark | 2026-03-01 |
+| 15 | Exa blog - Company Search Benchmarks | blog-official | https://exa.ai/blog/company-search-benchmarks | 2026-03-01 |
+| 16 | Exa docs - LangChain integration | official-docs | https://docs.exa.ai/reference/langchain | 2026-03-01 |
+| 17 | Exa docs - LlamaIndex integration | official-docs | https://docs.exa.ai/reference/llamaindex | 2026-03-01 |
+| 18 | Exa docs - CrewAI integration | official-docs | https://docs.exa.ai/reference/crewai | 2026-03-01 |
+| 19 | Exa docs - Vercel AI SDK integration | official-docs | https://docs.exa.ai/reference/vercel | 2026-03-01 |
+| 20 | Exa docs - MCP | official-docs | https://docs.exa.ai/reference/exa-mcp | 2026-03-01 |
+| 21 | Exa docs - Websets FAQ | official-docs | https://docs.exa.ai/websets/faq | 2026-03-01 |
+| 22 | Exa About page | official-docs | https://exa.ai/about | 2026-03-01 |
+| 23 | GitHub - exa-labs org | github-repo | https://github.com/exa-labs | 2026-03-01 |
+| 24 | GitHub - exa-py | github-repo | https://github.com/exa-labs/exa-py | 2026-03-01 |
+| 25 | GitHub - exa-js | github-repo | https://github.com/exa-labs/exa-js | 2026-03-01 |
+| 26 | GitHub - exa-mcp-server | github-repo | https://github.com/exa-labs/exa-mcp-server | 2026-03-01 |
+| 27 | GitHub - exa-labs/ai-sdk | github-repo | https://github.com/exa-labs/ai-sdk | 2026-03-01 |
+| 28 | GitHub - exa OpenAPI spec | github-repo | https://raw.githubusercontent.com/exa-labs/openapi-spec/refs/heads/master/exa-openapi-spec.yaml | 2026-03-01 |
+| 29 | PyPI - exa-py | api-reference | https://pypi.org/project/exa-py/ | 2026-03-01 |
+| 30 | PyPI - langchain-exa | api-reference | https://pypi.org/project/langchain-exa/0.1.0/ | 2026-03-01 |
+| 31 | PyPI - llama-index-tools-exa | api-reference | https://pypi.org/project/llama-index-tools-exa/ | 2026-03-01 |
+| 32 | npm - exa-js | api-reference | https://www.npmjs.com/package/exa-js | 2026-03-01 |
+| 33 | npm - @exalabs/ai-sdk | api-reference | https://www.npmjs.com/package/@exalabs/ai-sdk | 2026-03-01 |
+| 34 | npm - @langchain/exa | api-reference | https://www.npmjs.com/package/@langchain/exa | 2026-03-01 |
+| 35 | LangChain API ref - ExaSearchRetriever | api-reference | https://python.langchain.com/api_reference/exa/retrievers/langchain_exa.retrievers.ExaSearchRetriever.html | 2026-03-01 |
+| 36 | LlamaIndex - Exa tools | api-reference | https://docs.llamaindex.ai/en/stable/api_reference/tools/exa/ | 2026-03-01 |
+| 37 | Y Combinator - Exa profile | official-docs | https://www.ycombinator.com/companies/exa | 2026-03-01 |
+| 38 | CB Insights - Metaphor/Exa | news | https://www.cbinsights.com/company/metaphor-1 | 2026-03-01 |
+| 39 | Cerebral Valley - Exa profile | blog-third-party | https://cerebralvalley.ai/blog/exa-aims-to-reshape-web-search-4AOjbOWK9sxxXCKdjQG1EK | 2026-03-01 |
+| 40 | SiliconANGLE - Series B coverage | news | https://siliconangle.com/2025/09/03/nvidia-backs-85m-round-ai-search-startup-exa/ | 2026-03-01 |
+| 41 | TechFundingNews - Series B coverage | news | https://techfundingnews.com/san-franciscos-exa-raises-85m-at-700m-valuation-to-build-the-search-engine-for-ai/ | 2026-03-01 |
+| 42 | MarkTechPost - Exa Instant coverage | news | https://www.marktechpost.com/2026/02/13/exa-ai-introduces-exa-instant-a-sub-200ms-neural-search-engine-designed-to-eliminate-bottlenecks-for-real-time-agentic-workflows/ | 2026-03-01 |
+| 43 | Data4AI - Exa review | blog-third-party | https://data4ai.com/blog/vendor-spotlights/exa-ai-review/ | 2026-03-01 |
+| 44 | Data4AI - Exa vs Tavily comparison | blog-third-party | https://data4ai.com/blog/tool-comparisons/exa-ai-vs-tavily/ | 2026-03-01 |
+| 45 | Skywork - Exa ultimate guide | blog-third-party | https://skywork.ai/skypage/en/Exa-AI-The-Ultimate-Guide-for-Developers-AI-Builders/1972878623855276032 | 2026-03-01 |
+| 46 | HumAI blog - AI search APIs compared | blog-third-party | https://www.humai.blog/ai-search-apis-compared-tavily-vs-exa-vs-perplexity/ | 2026-03-01 |
+| 47 | DEV Community - SERP API comparison 2025 | blog-third-party | https://dev.to/ritza/best-serp-api-comparison-2025-serpapi-vs-exa-vs-tavily-vs-scrapingdog-vs-scrapingbee-2jci | 2026-03-01 |
+| 48 | Firecrawl - Exa alternatives | blog-third-party | https://www.firecrawl.dev/blog/exa-alternatives | 2026-03-01 |
+| 49 | 10Web - Exa review | blog-third-party | https://10web.io/ai-tools/exa/ | 2026-03-01 |
+| 50 | FindMyAITool - Exa review 2026 | blog-third-party | https://findmyaitool.io/tool/exa/ | 2026-03-01 |
+| 51 | Evolv Agency - Exa Explained | blog-third-party | https://evolvagency.io/learn/generative-search/what-is-exa | 2026-03-01 |
+| 52 | Hacker News - Exa pricing discussion | community | https://news.ycombinator.com/item?id=43910228 | 2026-03-01 |
+| 53 | LangChain GitHub - Exa tools source | github-repo | https://github.com/langchain-ai/langchain/blob/master/libs/partners/exa/langchain_exa/tools.py | 2026-03-01 |
+| 54 | LlamaIndex GitHub - Exa tools | github-repo | https://github.com/run-llama/llama_index/tree/main/llama-index-integrations/tools/llama-index-tools-exa | 2026-03-01 |
+| 55 | AWS Marketplace - Exa | official-docs | https://aws.amazon.com/marketplace/pp/prodview-d5kxpjxyrsdkw | 2026-03-01 |
+
+<!--
+Source Types:
+  official-docs  - Official documentation / API reference
+  api-reference  - Detailed API/SDK documentation
+  github-repo    - GitHub repository README, code, issues
+  blog-official  - Official blog post from the tool's org
+  blog-third-party - Third-party blog, comparison article
+  benchmark      - Independent benchmark or test results
+  news           - News article or press release
+  community      - Forum post, Discord, Stack Overflow
+  inference      - Derived/inferred from other data (flag for verification)
+-->

--- a/data/tools/search-apis/perplexity-sonar.md
+++ b/data/tools/search-apis/perplexity-sonar.md
@@ -1,0 +1,365 @@
+# Perplexity Sonar API
+
+<!--
+COLLECTION METADATA
+==================
+Collected: 2026-03-01
+Collector: claude-opus-4-6
+Session: agent-search-landscape research
+GitHub Issue: N/A
+Collection Method: WebSearch with cross-referencing against official docs URLs
+Last Verified: 2026-03-01
+Confidence: medium — Assembled from WebSearch results referencing official docs; WebFetch to docs.perplexity.ai was unavailable, so direct page verification was not possible. Pricing and model details cross-referenced across multiple sources.
+-->
+
+## Identity & Basics
+
+| Field | Value | Source |
+|-------|-------|--------|
+| Organization | Perplexity AI (founded August 2022 by Aravind Srinivas, Denis Yarats, Andy Konwinski, Johnny Ho) | <!-- https://en.wikipedia.org/wiki/Perplexity_AI --> |
+| Website | https://sonar.perplexity.ai/ (API platform); https://www.perplexity.ai/ (consumer product) | <!-- https://www.perplexity.ai/api-platform --> |
+| License | Proprietary / Commercial API. Governed by Perplexity API Terms of Service. Commercial use permitted but AUP prohibits building competitive products or redistributing the service. | <!-- https://www.perplexity.ai/hub/legal/perplexity-api-terms-of-service --> |
+| Launch Date | Sonar API: January 21, 2025. Search API: September 25, 2025. | <!-- https://techcrunch.com/2025/01/21/perplexity-launches-sonar-an-api-for-ai-search/ ; https://www.perplexity.ai/hub/blog/introducing-the-perplexity-search-api --> |
+| GitHub (Official) | https://github.com/perplexityai (org); key repos: perplexity-py, perplexity-node, modelcontextprotocol | <!-- https://github.com/perplexityai --> |
+| GitHub Stars | Not confirmed via direct page load — repos are relatively new (2025) | <!-- as of 2026-03-01 --> |
+| Community Size | Discord: ~375K members; API forum: community.perplexity.ai (~12K queries/month); Developer integrations: ~85K active (as of mid-2025) | <!-- https://discord.com/servers/perplexity-1047197230748151888 ; https://sqmagazine.co.uk/perplexity-ai-statistics/ --> |
+
+## Category Placement
+
+- **Primary**: Search API (AI-powered web search with synthesized answers)
+- **Secondary**: LLM API (chat completions with grounding), Research API (deep research mode)
+
+## Core Capability
+
+> Perplexity Sonar provides an API for AI-powered web search that returns synthesized natural-language answers with inline citations, grounded in real-time web data from an index of hundreds of billions of pages -- not just raw search results, but actual answers.
+
+## API Surface
+
+<!-- Sources: https://docs.perplexity.ai/api-reference/chat-completions-post ; https://docs.perplexity.ai/api-reference/search-post ; https://docs.perplexity.ai/guides/getting-started ; https://docs.perplexity.ai/guides/chat-completions-guide -->
+
+### Endpoints / Methods
+
+| Endpoint | Purpose | Input | Output |
+|----------|---------|-------|--------|
+| `POST /chat/completions` | AI-synthesized answers with web search grounding and citations | OpenAI-compatible messages array + model name | Streamed or complete chat response with citations array and search_results metadata |
+| `POST /search` | Raw ranked web search results (no AI synthesis) | Query string + optional filters (domain, date, region) | Array of ranked result objects with title, URL, snippet, date, last_updated |
+
+### Models Available (Sonar Family)
+
+| Model ID | Category | Context Window | Description |
+|----------|----------|---------------|-------------|
+| `sonar` | Search | 128K tokens | Lightweight, fast grounded search. Built on Llama 3.3 70B. |
+| `sonar-pro` | Search | 200K tokens | Deeper retrieval, multi-step queries, ~2x citations vs sonar |
+| `sonar-reasoning` | Reasoning | 128K tokens | Real-time reasoning with search (chain-of-thought) |
+| `sonar-reasoning-pro` | Reasoning | 128K tokens | Advanced reasoning powered by DeepSeek-R1 with search |
+| `sonar-deep-research` | Research | 128K tokens | Long-form, source-dense research reports; multi-step search |
+
+**Deprecated model IDs:** `llama-3.1-sonar-*-128k-online`, `pplx-*` (migrated to `sonar*` family).
+
+### Search Modes (for Sonar, Sonar Pro, Sonar Reasoning Pro)
+
+| Mode | Behavior | Cost Impact |
+|------|----------|-------------|
+| `high` | Maximum search depth and context for complex queries | Highest per-request fee |
+| `medium` | Balanced depth for moderately complex questions | Mid-range per-request fee |
+| `low` | Cost-optimized, strong accuracy for straightforward queries | Lowest per-request fee |
+
+### Authentication
+
+- **Method:** Bearer token via `Authorization` header
+- **Format:** `Authorization: Bearer <PERPLEXITY_API_KEY>`
+- **Key generation:** Via Perplexity web console at https://www.perplexity.ai/account/api/keys (requires creating an API Group first)
+- **Programmatic key generation:** `POST https://api.perplexity.ai/generate_auth_token` with Bearer auth and optional `token_name` parameter
+
+### Rate Limits
+
+| Model | Requests Per Minute (RPM) | Notes |
+|-------|--------------------------|-------|
+| `sonar` | Up to 4,000 RPM | Tier-dependent |
+| `sonar-pro` | Up to 4,000 RPM | Tier-dependent |
+| `sonar-reasoning-pro` | Up to 4,000 RPM | Tier-dependent |
+| `sonar-deep-research` | 100 RPM | Lower due to multi-step nature |
+| Search API | 50 req/sec (burst: 50) | Independent of usage tier |
+
+**Usage Tiers (0-5):** Rate limits scale with cumulative spend. Tier 0 (new accounts) has the most restrictions; Tier 5 ($5,000+ lifetime spend) offers highest limits.
+
+**Rate limiting algorithm:** Leaky bucket (allows burst traffic while maintaining long-term rate control).
+
+### Input/Output Formats
+
+**Chat Completions (OpenAI-compatible):**
+- Input: JSON body with `model`, `messages` (array of role/content), optional `temperature` (0-2), `max_tokens`, `stream` (boolean), `search_context_size` ("low"/"medium"/"high"), `search_recency_filter`, `search_domain_filter` (up to 20 domains), `response_format` (JSON schema for structured output), `return_images` (Tier 2+)
+- Output: Standard chat completion object + `citations` array (URLs) + `search_results` array (title, URL, snippet, date, source)
+- Streaming: Supported via server-sent events (SSE)
+
+**Image input:** Supported. Base64 data URIs or HTTPS URLs. Formats: PNG, JPEG, WEBP, GIF. Max 50MB.
+
+**Structured output:** JSON Schema via `response_format` parameter. Note: first request with a new schema may take 10-30s. Recursive schemas and unconstrained objects not supported.
+
+**Search API:**
+- Input: Query string + optional `search_recency_filter`, `search_domain_filter`, region targeting
+- Output: Array of result objects: `{ title, url, snippet, date, last_updated }`
+
+## Pricing
+
+<!-- Sources: https://docs.perplexity.ai/docs/getting-started/pricing ; https://www.glbgpt.com/hub/perplexity-api-cost-2025/ ; https://pricepertoken.com/pricing-page/provider/perplexity ; https://www.finout.io/blog/perplexity-pricing-in-2026 -->
+<!-- Pricing as of: 2026-03-01 -->
+
+### Token Pricing
+
+| Model | Input (per 1M tokens) | Output (per 1M tokens) |
+|-------|-----------------------|------------------------|
+| `sonar` | $1.00 | $1.00 |
+| `sonar-pro` | $3.00 | $15.00 |
+| `sonar-reasoning` | $2.00 | $8.00 |
+| `sonar-reasoning-pro` | $2.00 | $8.00 |
+| `sonar-deep-research` | $2.00 (input) | $8.00 (output) |
+
+**Note on sonar-deep-research:** Pricing has additional components -- $5/1,000 searches performed during research; reasoning tokens at $3/1M tokens; input tokens include both prompt tokens and citation tokens from search runs.
+
+### Per-Request Fees (by search_context_size)
+
+| Model Family | Low (per 1K req) | Medium (per 1K req) | High (per 1K req) |
+|-------------|-------------------|---------------------|---------------------|
+| Sonar / Sonar Reasoning | $5 | $8 | $12 |
+| Sonar Pro / Sonar Reasoning Pro | $6 | $10 | $14 |
+
+### Search API Pricing
+
+| Endpoint | Price |
+|----------|-------|
+| Search API (`POST /search`) | $5 per 1,000 requests (no additional token-based pricing) |
+
+### Citation Token Billing
+
+As of 2025/2026: Citation tokens are **no longer billed** for Sonar and Sonar Pro models (except Sonar Deep Research). This simplifies billing and reduces effective costs.
+
+### Per-Unit Economics at Scale
+
+**Example (sonar, low context):** A basic query with 500 input tokens + 200 output tokens at low search context = ~$0.0057 per query ($0.005 request fee + ~$0.0007 tokens).
+
+**Example (sonar-pro, high context):** A complex query with 1,000 input tokens + 500 output tokens at high search context = ~$0.0215 per query ($0.014 request fee + $0.003 input + $0.0075 output).
+
+**At 1M queries/month (sonar, low):** ~$5,700/month in request fees + token costs.
+
+**At 1M queries/month (sonar-pro, high):** ~$21,500/month.
+
+## Technical Architecture
+
+<!-- Sources: https://www.perplexity.ai/hub/blog/introducing-the-perplexity-search-api ; https://rankstudio.net/articles/en/perplexity-llm-tech-stack ; https://www.perplexity.ai/hub/blog/meet-new-sonar -->
+
+### How It Works
+
+**Web Index:** Perplexity maintains a proprietary web index covering hundreds of billions of pages. The index processes tens of thousands of update requests per second to maintain freshness. Machine learning models prioritize crawling and indexing, predicting URL importance based on factors like update frequency.
+
+**Content Understanding:** An AI-powered content understanding module dynamically generates parsing logic (using frontier LLMs) to handle diverse website layouts. The module self-improves via iterative evaluation loops, processing millions of queries hourly.
+
+**Retrieval Pipeline (multi-stage):**
+1. **Hybrid retrieval** -- generates initial candidates using combined semantic + lexical methods
+2. **Pre-filtering** -- removes noise
+3. **Progressive ranking** -- applies lexical scoring, embedding-based similarity, and cross-encoder models
+4. **Sub-document chunking** -- documents are divided into fine-grained units; individual chunks are scored against the query for precise relevance
+
+**Answer Generation:** Retrieved content is passed to the Sonar model family (built on Llama 3.3 70B for base Sonar), which synthesizes a natural-language answer with inline citations. The model has been specifically fine-tuned for web-grounded, real-time answers.
+
+**Inference:** Sonar runs on Cerebras inference infrastructure, achieving up to 1,200 tokens/second for fast answer generation.
+
+### Models / Infrastructure
+
+| Component | Detail |
+|-----------|--------|
+| Base model (Sonar) | Fine-tuned Llama 3.3 70B, optimized for search-grounded Q&A |
+| Reasoning backbone | DeepSeek-R1 (for sonar-reasoning-pro) |
+| Inference provider | Cerebras (high-speed inference) |
+| Search index | Proprietary; hundreds of billions of pages; real-time updates |
+| Content parsing | AI-powered dynamic parsing with LLM-driven adaptation |
+
+### Consumer Product vs API Relationship
+
+The consumer product (perplexity.ai / app) and the Sonar API share the same underlying search infrastructure and index. However:
+- The API model may differ from the UI model for equivalent queries
+- The API provides configurable parameters (search context size, domain filters, structured output) not exposed in the consumer UI
+- Deep Research was integrated into Sonar's API architecture in April 2025
+
+### Search API vs Chat Completions API
+
+| Dimension | Chat Completions (`/chat/completions`) | Search API (`/search`) |
+|-----------|----------------------------------------|----------------------|
+| Output | AI-synthesized answer + citations + search_results | Raw ranked result objects (title, URL, snippet) |
+| Use case | Conversational search, Q&A, research synthesis | Programmatic access to ranked web results |
+| Pricing | Token-based + per-request fee | Per-request only ($5/1K) |
+| AI synthesis | Yes (full LLM generation) | No (structured data only) |
+| Customization | Messages, temperature, streaming, JSON schema | Domain filters, date range, region targeting |
+
+### Self-Host Options
+
+None. Perplexity Sonar is a fully managed cloud API. No self-hosting, on-premise, or open-source deployment option.
+
+## Integration Surface
+
+<!-- Sources: https://docs.perplexity.ai/guides/perplexity-sdk ; https://github.com/perplexityai ; https://docs.perplexity.ai/guides/mcp-server ; https://docs.llamaindex.ai/en/stable/examples/llm/perplexity/ ; https://python.langchain.com/docs/integrations/chat/perplexity/ ; https://ai-sdk.dev/providers/ai-sdk-providers/perplexity -->
+
+| Integration | Status | Notes |
+|------------|--------|-------|
+| MCP Server | Official | `perplexityai/modelcontextprotocol` on GitHub. Install via `npx -y @perplexity-ai/mcp-server`. Supports all Sonar models + Search API. |
+| Python SDK | Official | `perplexityai/perplexity-py` on GitHub. Python 3.9+. Sync + async (httpx). Install: `pip install perplexity-ai` (or similar). |
+| Node/TS SDK | Official | `perplexityai/perplexity-node` on GitHub. npm: `@perplexity-ai/perplexity_ai`. Node 20+, Deno 1.28+, Bun 1.0+, Cloudflare Workers, Vercel Edge Runtime. Generated with Stainless. |
+| OpenAI SDK Compatible | Yes (drop-in) | Change `base_url` to `https://api.perplexity.ai` in any OpenAI client. Works with Python `openai` and JS `openai` packages. |
+| LangChain | Available | `ChatPerplexity` class in LangChain. Docs at python.langchain.com/docs/integrations/chat/perplexity/. |
+| LlamaIndex | Available | `llama-index-llms-perplexity` package on PyPI. Supports sync/async chat completions and streaming. Default model: sonar-pro. |
+| Vercel AI SDK | Available | `@ai-sdk/perplexity` npm package. Documented at ai-sdk.dev. |
+| LiteLLM | Available | Provider: `perplexity`. Documented at docs.litellm.ai/docs/providers/perplexity. |
+| CrewAI | Community/Partial | Works via LiteLLM integration. Some users report issues with newer Sonar models vs deprecated PPLX models. Not an official, dedicated integration. |
+| Cloudflare AI Gateway | Available | Documented proxy support at developers.cloudflare.com/ai-gateway. |
+| OpenRouter | Available | All Sonar models available via OpenRouter as a provider. |
+| Promptfoo | Available | Provider integration documented at promptfoo.dev. |
+
+## Performance Data
+
+<!-- Sources: https://www.perplexity.ai/hub/blog/perplexity-sonar-dominates-new-search-arena-evolution ; https://www.perplexity.ai/hub/blog/new-sonar-search-modes-outperform-openai-in-cost-and-performance ; https://artificialanalysis.ai/providers/perplexity ; https://www.perplexity.ai/hub/blog/meet-new-sonar -->
+
+### Published Benchmarks
+
+| Benchmark | Model | Score | Comparison |
+|-----------|-------|-------|------------|
+| Search Arena | sonar-reasoning-pro | Score 1136 | Statistically tied with Gemini-2.5-Pro-Grounding (1142); beat it 53% in head-to-head |
+| SimpleQA (F-score) | sonar-pro | 0.858 | Leads the benchmark |
+| SimpleQA (F-score) | sonar | 0.773 | Strong for lightweight model |
+
+**Claim:** Sonar and Sonar Pro outperform search-enabled GPT-4o on factuality while maintaining lower pricing.
+
+### Speed Claims
+
+| Metric | Value | Source |
+|--------|-------|--------|
+| Peak token generation (Cerebras) | ~1,200 tokens/sec | Perplexity blog (Meet New Sonar) |
+| Measured output speed | 121.1 tokens/sec | Artificial Analysis benchmarks |
+| Time to first token (TTFT) | 1.33 seconds | Artificial Analysis benchmarks |
+
+### Accuracy / Coverage Claims
+
+- Index covers "hundreds of billions of web pages" with "tens of thousands of index update requests per second"
+- Sonar Pro provides approximately 2x the citations per search compared to base Sonar
+- ~780 million queries processed monthly on the consumer product (as of Sept 2025)
+- Citation tokens are free (not billed), encouraging comprehensive sourcing
+
+## Limitations
+
+<!-- Sources: https://docs.perplexity.ai/faq/faq ; https://community.perplexity.ai/ ; https://ai-sdk.dev/providers/ai-sdk-providers/perplexity -->
+
+### What It Can't Do
+
+- **No self-hosting or on-premise deployment** -- fully managed cloud API only
+- **No image generation** -- can return images from search (Tier 2+) but does not generate them
+- **No fine-tuning** -- you cannot fine-tune Sonar models; they are fixed
+- **No guaranteed uptime SLA** -- Perplexity does not guarantee service uptime, failure frequency, or target recovery time
+- **No recursive JSON schemas** -- structured output does not support recursive structures or unconstrained objects
+- **No real-time chat memory** -- each API call is stateless; no built-in conversation persistence
+
+### Known Failure Modes
+
+- **sonar-deep-research timeouts:** Users report consistent timeouts after ~60 seconds on complex report generation tasks. Simple requests work fine; complex multi-step research can fail.
+- **Reasoning token leakage:** sonar-reasoning-pro outputs a `<think>` section containing reasoning tokens before the actual JSON response. The `response_format` parameter does not remove these reasoning tokens.
+- **Cold-start on structured output:** First request with a new JSON schema may take 10-30 seconds to process.
+- **Rate limit 429 errors:** Especially on Tier 0 accounts with low RPM limits; leaky bucket algorithm means burst traffic may be silently queued.
+- **API vs UI divergence:** The underlying AI model may differ between API and consumer UI for equivalent queries.
+
+### Documented Issues
+
+- **Domain filter limit:** Expanded to 20 entries as of August 2025 (previously lower)
+- **search_recency_filter:** Filters by `last_updated` date; format is `%m/%d/%Y`. Can miss content that was published recently but indexed with older dates.
+- **Token counting inconsistencies:** Some third-party integrations (e.g., LangChain `max_tokens`) have reported parameter handling issues (see langchain-ai/langchain#28229).
+- **Deprecated model migration:** Older model IDs (`llama-3.1-sonar-*-128k-online`, `pplx-*`) have been deprecated. Applications using old IDs need migration to new `sonar*` family.
+
+## Differentiation
+
+> **What makes Perplexity Sonar unique vs. same-category alternatives:**
+>
+> 1. **Synthesized answers, not just search results.** Unlike Google Custom Search, Bing Web Search, or Brave Search API which return ranked links/snippets, Sonar returns a complete natural-language answer synthesized from multiple web sources. It is search + LLM in one API call.
+>
+> 2. **Built-in citations.** Every response includes inline citations with source URLs, enabling verifiable, grounded AI responses without building your own RAG pipeline.
+>
+> 3. **Real-time web grounding.** The proprietary index of hundreds of billions of pages with sub-second update rates means responses reflect current information, not stale training data.
+>
+> 4. **Model family spanning speed-to-depth spectrum.** From lightweight `sonar` (fast, cheap) to `sonar-deep-research` (thorough, multi-step) -- one API, multiple depth levels.
+>
+> 5. **OpenAI-compatible drop-in.** Uses the standard chat completions format, so any OpenAI client works with a base URL change. Minimal integration friction.
+>
+> 6. **Search + Chat API duality.** Both raw search results (Search API) and synthesized answers (Chat Completions) from the same infrastructure, letting developers choose their level of control.
+>
+> 7. **Cerebras-powered inference.** Peak speeds of ~1,200 tokens/sec enable near-instant answer generation for the search use case.
+
+## Raw Notes
+
+- Perplexity AI crossed $100M ARR by March 2025 and ~$200M by late 2025. Valuation reached $20B in Sept 2025.
+- The company processes ~360M+ monthly API calls (separate from consumer product volume).
+- The Sonar model was initially announced January 21, 2025 (TechCrunch coverage). The "Meet New Sonar" refresh (built on Llama 3.3 70B) came February 11, 2025.
+- Deep Research was integrated into Sonar API in April 2025.
+- The standalone Search API (returning raw results, no synthesis) launched September 25, 2025.
+- Three search modes (high/medium/low) introduced alongside updated pricing in 2025.
+- Perplexity's GitHub org operates under both `perplexityai` and `ppl-ai` namespaces.
+- The MCP server is available as both an official npm package (`@perplexity-ai/mcp-server`) and via several community implementations.
+- OpenRouter lists all Sonar models as available providers.
+
+## Source Log
+
+<!-- Complete list of all sources consulted for this profile -->
+
+| # | Source | Type | URL | Accessed |
+|---|--------|------|-----|----------|
+| 1 | Perplexity API Docs (main) | official-docs | https://docs.perplexity.ai/ | 2026-03-01 |
+| 2 | Perplexity API Pricing | official-docs | https://docs.perplexity.ai/docs/getting-started/pricing | 2026-03-01 |
+| 3 | Perplexity Chat Completions API Reference | api-reference | https://docs.perplexity.ai/api-reference/chat-completions-post | 2026-03-01 |
+| 4 | Perplexity Search API Reference | api-reference | https://docs.perplexity.ai/api-reference/search-post | 2026-03-01 |
+| 5 | Perplexity SDK Quickstart | official-docs | https://docs.perplexity.ai/guides/perplexity-sdk | 2026-03-01 |
+| 6 | Perplexity MCP Server Guide | official-docs | https://docs.perplexity.ai/guides/mcp-server | 2026-03-01 |
+| 7 | Perplexity OpenAI Compatibility Guide | official-docs | https://docs.perplexity.ai/guides/chat-completions-guide | 2026-03-01 |
+| 8 | Perplexity Image Attachments Guide | official-docs | https://docs.perplexity.ai/guides/image-attachments | 2026-03-01 |
+| 9 | Perplexity API Key Management | official-docs | https://docs.perplexity.ai/guides/api-key-management | 2026-03-01 |
+| 10 | Perplexity Changelog | official-docs | https://docs.perplexity.ai/changelog/changelog | 2026-03-01 |
+| 11 | Perplexity API Platform (Sonar) | official-docs | https://sonar.perplexity.ai/ | 2026-03-01 |
+| 12 | TechCrunch: Perplexity launches Sonar | news | https://techcrunch.com/2025/01/21/perplexity-launches-sonar-an-api-for-ai-search/ | 2026-03-01 |
+| 13 | Blog: Introducing Sonar Pro API | blog-official | https://www.perplexity.ai/hub/blog/introducing-the-sonar-pro-api | 2026-03-01 |
+| 14 | Blog: Meet New Sonar | blog-official | https://www.perplexity.ai/hub/blog/meet-new-sonar | 2026-03-01 |
+| 15 | Blog: Introducing the Perplexity Search API | blog-official | https://www.perplexity.ai/hub/blog/introducing-the-perplexity-search-api | 2026-03-01 |
+| 16 | Blog: Improved Sonar Models | blog-official | https://www.perplexity.ai/hub/blog/new-sonar-search-modes-outperform-openai-in-cost-and-performance | 2026-03-01 |
+| 17 | Blog: Sonar Dominates Search Arena | blog-official | https://www.perplexity.ai/hub/blog/perplexity-sonar-dominates-new-search-arena-evolution | 2026-03-01 |
+| 18 | GitHub: perplexityai/perplexity-py | github-repo | https://github.com/perplexityai/perplexity-py | 2026-03-01 |
+| 19 | GitHub: perplexityai/perplexity-node | github-repo | https://github.com/perplexityai/perplexity-node | 2026-03-01 |
+| 20 | GitHub: perplexityai/modelcontextprotocol | github-repo | https://github.com/perplexityai/modelcontextprotocol | 2026-03-01 |
+| 21 | npm: @perplexity-ai/perplexity_ai | api-reference | https://www.npmjs.com/package/@perplexity-ai/perplexity_ai | 2026-03-01 |
+| 22 | PyPI: llama-index-llms-perplexity | api-reference | https://pypi.org/project/llama-index-llms-perplexity/ | 2026-03-01 |
+| 23 | LangChain Perplexity Integration | official-docs | https://python.langchain.com/docs/integrations/chat/perplexity/ | 2026-03-01 |
+| 24 | LlamaIndex Perplexity Docs | official-docs | https://docs.llamaindex.ai/en/stable/examples/llm/perplexity/ | 2026-03-01 |
+| 25 | Vercel AI SDK: Perplexity Provider | official-docs | https://ai-sdk.dev/providers/ai-sdk-providers/perplexity | 2026-03-01 |
+| 26 | LiteLLM: Perplexity Provider | official-docs | https://docs.litellm.ai/docs/providers/perplexity | 2026-03-01 |
+| 27 | Artificial Analysis: Perplexity | benchmark | https://artificialanalysis.ai/providers/perplexity | 2026-03-01 |
+| 28 | OpenRouter: Perplexity Models | api-reference | https://openrouter.ai/perplexity | 2026-03-01 |
+| 29 | Helicone: Sonar Pricing Calculator | blog-third-party | https://www.helicone.ai/llm-cost/provider/perplexity/model/sonar | 2026-03-01 |
+| 30 | pricepertoken.com: Perplexity API Pricing | blog-third-party | https://pricepertoken.com/pricing-page/provider/perplexity | 2026-03-01 |
+| 31 | Global GPT: Perplexity API Cost 2025 | blog-third-party | https://www.glbgpt.com/hub/perplexity-api-cost-2025/ | 2026-03-01 |
+| 32 | Finout: Perplexity Pricing in 2026 | blog-third-party | https://www.finout.io/blog/perplexity-pricing-in-2026 | 2026-03-01 |
+| 33 | SQ Magazine: Perplexity AI Statistics 2025 | news | https://sqmagazine.co.uk/perplexity-ai-statistics/ | 2026-03-01 |
+| 34 | Perplexity API Terms of Service | official-docs | https://www.perplexity.ai/hub/legal/perplexity-api-terms-of-service | 2026-03-01 |
+| 35 | Perplexity Acceptable Use Policy | official-docs | https://www.perplexity.ai/hub/legal/aup | 2026-03-01 |
+| 36 | Wikipedia: Perplexity AI | news | https://en.wikipedia.org/wiki/Perplexity_AI | 2026-03-01 |
+| 37 | RankStudio: Perplexity LLM Tech Stack | blog-third-party | https://rankstudio.net/articles/en/perplexity-llm-tech-stack | 2026-03-01 |
+| 38 | Perplexity API Forum: Sonar Deep Research Timeout | community | https://community.perplexity.ai/t/perplexity-sonar-deep-research-model-timeout-issue-seeking-solution/2094 | 2026-03-01 |
+| 39 | Perplexity API Forum: August 2025 Updates | community | https://community.perplexity.ai/t/sonar-api-updates-august-29-2025/1252 | 2026-03-01 |
+| 40 | Cloudflare AI Gateway: Perplexity | official-docs | https://developers.cloudflare.com/ai-gateway/usage/providers/perplexity/ | 2026-03-01 |
+| 41 | InfoQ: Perplexity Search API Launch | news | https://www.infoq.com/news/2025/09/perplexity-search-api/ | 2026-03-01 |
+| 42 | Promptfoo: Perplexity Provider | official-docs | https://www.promptfoo.dev/docs/providers/perplexity/ | 2026-03-01 |
+| 43 | DeepWiki: perplexity-node Search API | blog-third-party | https://deepwiki.com/perplexityai/perplexity-node/4.1-search-api | 2026-03-01 |
+
+<!--
+Source Types:
+  official-docs  - Official documentation / API reference
+  api-reference  - Detailed API/SDK documentation
+  github-repo    - GitHub repository README, code, issues
+  blog-official  - Official blog post from the tool's org
+  blog-third-party - Third-party blog, comparison article
+  benchmark      - Independent benchmark or test results
+  news           - News article or press release
+  community      - Forum post, Discord, Stack Overflow
+  inference      - Derived/inferred from other data (flag for verification)
+-->

--- a/data/tools/search-apis/serpapi.md
+++ b/data/tools/search-apis/serpapi.md
@@ -1,0 +1,356 @@
+# SerpAPI
+
+<!--
+COLLECTION METADATA
+==================
+Collected: 2026-03-01
+Collector: claude-opus-4-6
+Session: agent-search-landscape research
+GitHub Issue: N/A
+Collection Method: WebSearch-based research with cross-referencing
+Last Verified: 2026-03-01
+Confidence: medium — WebFetch unavailable; pricing and engine counts cross-referenced across multiple third-party sources but official docs not directly scraped
+-->
+
+## Identity & Basics
+
+| Field | Value | Source |
+|-------|-------|--------|
+| Organization | SerpApi (private company) | <!-- https://www.crunchbase.com/organization/serpapi --> |
+| Founder/CEO | Julien Khaleghy | <!-- https://www.crunchbase.com/person/julien-khalegy --> |
+| Website | https://serpapi.com | |
+| License | Proprietary SaaS (SDKs and MCP server are MIT-licensed open source) | <!-- https://github.com/serpapi/serpapi-mcp --> |
+| Founded | 2017 (some sources say 2016; 2017 is more commonly cited) | <!-- https://www.crunchbase.com/organization/serpapi, https://techcrunch.com/sponsor/serpapi/ --> |
+| Headquarters | Austin, Texas, USA | <!-- https://www.crunchbase.com/organization/serpapi --> |
+| GitHub Org | https://github.com/serpapi (98 repositories) | <!-- https://github.com/serpapi --> |
+| GitHub Stars (legacy Python SDK) | ~731 stars (google-search-results-python) | <!-- https://github.com/serpapi/google-search-results-python, as of 2026-03-01 --> |
+| GitHub Stars (new Python SDK) | ~121 stars (serpapi-python) | <!-- https://github.com/serpapi/serpapi-python, as of 2026-03-01 --> |
+| GitHub Stars (JS SDK) | ~75 stars (serpapi-javascript) | <!-- https://github.com/serpapi, as of 2026-03-01 --> |
+| Revenue | ~$3M ARR (as of 2025) | <!-- https://getlatka.com/companies/serpapi.com --> |
+| Team Size | ~27 employees (as of 2025) | <!-- https://getlatka.com/companies/serpapi.com --> |
+| npm Weekly Downloads | ~55,189 (serpapi package) | <!-- https://socket.dev/npm/package/serpapi, as of 2026-03-01 --> |
+
+## Category Placement
+
+- **Primary**: SERP Scraping API / Search Data Extraction
+- **Secondary**: Web Search API for AI/LLM applications, SEO Data Provider
+
+## Core Capability
+
+> SerpAPI is a real-time SERP (Search Engine Results Page) scraping proxy that fetches, renders, and parses search engine results from 80+ search engines into structured JSON, handling all anti-bot detection, CAPTCHA solving, proxy rotation, and JavaScript rendering transparently behind a simple REST API.
+
+## API Surface
+
+<!-- Sources: https://serpapi.com/search-api, https://serpapi.com/search-engine-apis, https://deepwiki.com/serpapi/serpapi-python/4-supported-search-engines, https://www.smashingmagazine.com/2025/09/serpapi-complete-api-fetching-search-engine-data/, https://www.kdnuggets.com/2025/11/serpapi/automating-web-search-data-collection-for-ai-models-with-serpapi -->
+
+### Endpoints / Methods
+
+The API is accessed via a single primary endpoint with an `engine` parameter that selects the search engine:
+
+**Primary endpoint:** `GET https://serpapi.com/search?engine={engine}&q={query}&api_key={key}`
+
+| Engine Category | Specific Engines | Purpose |
+|-----------------|-----------------|---------|
+| **Web Search** | Google Search, Google Light, Bing, DuckDuckGo, Yahoo, Baidu, Yandex, Naver | General web search results |
+| **Google Verticals** | Google Images, Google News, Google Videos, Google Shopping, Google Maps, Google Local, Google Flights, Google Finance, Google Trends, Google Jobs, Google Scholar, Google Patents, Google Play | Specialized Google result types |
+| **E-commerce** | Amazon, Walmart, eBay, Home Depot | Product listings, pricing, reviews |
+| **App Stores** | Apple App Store, Google Play Store | App search and metadata |
+| **Other** | YouTube Search | Video search and metadata |
+
+**Total count:** SerpAPI claims 80+ search engines / 100+ APIs. The distinction is that individual Google verticals (Images, News, Shopping, etc.) each count as separate APIs.
+
+**Supplementary endpoints:**
+| Endpoint | Purpose | Input | Output |
+|----------|---------|-------|--------|
+| `/search` | Primary search endpoint | `engine`, `q`, `api_key`, location/language params | JSON (structured results) or raw HTML |
+| `/account` | Account info and usage | `api_key` | JSON (plan, usage, limits) |
+| `/locations` | Location lookup | `q` (location string) | JSON (location IDs for geo-targeting) |
+| Google Light API | Faster, leaner Google organic results | Same as `/search` with `engine=google_light` | JSON (organic results, knowledge graph, related questions only) |
+
+### Authentication
+
+- **Method:** API key passed as `api_key` query parameter on every request
+- **Alternative:** `Authorization: Bearer {api_key}` header
+- **MCP endpoint:** API key embedded in URL path: `https://mcp.serpapi.com/{API_KEY}/mcp`
+- **Key obtained:** Free registration at serpapi.com; key visible in dashboard
+
+### Rate Limits
+
+Rate limits are tied to plan tier and calculated as a percentage of monthly allocation:
+
+| Plan | Monthly Searches | Hourly Throughput Limit | Calculation |
+|------|-----------------|------------------------|-------------|
+| Free | 100 | ~20 | 20% of monthly |
+| Developer | 5,000 | 1,000 | 20% of monthly |
+| Production | 15,000 | 3,000 | 20% of monthly |
+| Big Data | 30,000 | 6,000 | 20% of monthly |
+| Enterprise (< 1M) | Custom | 20% of monthly volume | 20% of monthly |
+| Enterprise (>= 1M) | Custom | 100,000 + 1% of monthly | Different formula |
+
+**Key detail:** For plans under 1M searches/month, hourly throughput is capped at 20% of monthly volume. For plans at or above 1M, the formula changes to 100,000 + 1% of monthly volume.
+
+### Input/Output Formats
+
+- **Input:** HTTP GET request with URL query parameters (engine, q, location, gl, hl, num, start, tbm, etc.)
+- **Output formats:**
+  - `output=json` (default) -- Structured, parsed JSON with named fields for each SERP feature
+  - `output=html` -- Raw HTML of the search results page
+- **Structured JSON fields include:** organic_results, knowledge_graph, answer_box, local_results, shopping_results, related_questions (People Also Ask), related_searches, top_stories, ads, ai_overview, and many more depending on engine
+
+## Pricing
+
+<!-- Sources: https://serpapi.com/pricing, https://serpapi.com/enterprise, https://serpapi.com/ludicrous-speed, https://www.searchcans.com/blog/serpapi-pricing-alternatives-comparison-2026/, https://www.trustradius.com/products/serpapi/pricing, https://serpapi.com/blog/breakdown-of-serpapis-subscriptions/ -->
+<!-- Pricing as of: 2026-03-01 -->
+
+| Tier | Price/Month | Searches/Month | Hourly Throughput | Speed | Notes |
+|------|-------------|----------------|-------------------|-------|-------|
+| Free | $0 | 100 | ~20/hr | Best Effort | Auto-refund on failures |
+| Developer | $75 | 5,000 | 1,000/hr | Best Effort | HTML + JSON output |
+| Production | $150 | 15,000 | 3,000/hr | Best Effort | HTML + JSON output |
+| Big Data | $275 | 30,000 | 6,000/hr | Best Effort (Medium Throughput); Legal US Shield | HTML + JSON output |
+| Enterprise | $3,750+ | 100,000+ (base) | Custom | Best Effort or Ludicrous | Custom contracts, 99.97% SLA, ZeroTrace eligible |
+
+**Note:** Some sources cite 6 pricing editions from $50-$2,500 (G2, GetApp). There may be additional tiers (e.g., a $50 Starter tier for 1,000 searches) or high-volume self-serve tiers between Big Data and Enterprise that are only visible after login. The four tiers above are confirmed across multiple sources.
+
+### Speed Upgrades (Ludicrous Speed)
+
+| Speed Tier | Multiplier vs. Best Effort | Cost Multiplier | Description |
+|------------|---------------------------|-----------------|-------------|
+| Best Effort | 1x (baseline) | 1x | Standard |
+| Ludicrous Speed | 2.2x faster | 2x price (searches count as 2) | 2x server resources, parallel requests |
+| Ludicrous Speed Max | ~2.4x faster (9.6% over Ludicrous) | 4x price (searches count as 4) | 4x server resources |
+
+**Enterprise on-demand pricing:**
+- Best Effort: $7.50 / 1,000 searches
+- Ludicrous Speed: $15.00 / 1,000 searches
+- Ludicrous Speed Max: $30.00 / 1,000 searches
+
+### Per-Unit Economics at Scale
+
+| Volume | Effective Cost/Search | Notes |
+|--------|----------------------|-------|
+| Free (100) | $0.00 | Limited to 100/month |
+| Developer (5K) | $0.015 ($15/1K) | Unused searches expire monthly |
+| Production (15K) | $0.010 ($10/1K) | Unused searches expire monthly |
+| Big Data (30K) | ~$0.0092 ($9.17/1K) | Unused searches expire monthly |
+| Enterprise (100K base) | ~$0.0375 ($37.50/1K base) or $7.50/1K on-demand | Volume discounts available |
+
+**Critical note on economics:** Monthly subscriptions operate on "use it or lose it" -- unused searches do not roll over. Third-party analysis estimates this inflates effective costs by 30-50% for workloads with variable traffic patterns.
+
+## Technical Architecture
+
+<!-- Sources: https://www.smashingmagazine.com/2025/09/serpapi-complete-api-fetching-search-engine-data/, https://serpapi.com/blog/demystify-a-serpapi-request/, https://serpapi.com/security, https://serpapi.com/zero-trace-mode, https://nodemaven.com/blog/serp-scraping-how-to-collect-search-engine-data-safely-with-proxies/ -->
+
+### How It Works
+
+SerpAPI operates as a SERP scraping proxy service. The request lifecycle:
+
+1. **API request received:** Client sends GET request with search parameters (engine, query, location, language, etc.)
+2. **Geo-routing:** SerpAPI's optimized routing selects appropriate proxy IPs for the target location, ensuring results match the requested geographic context
+3. **Full browser rendering:** Each API request runs in a full browser environment (not simple HTTP requests). This handles JavaScript-heavy SERPs and dynamic content loading
+4. **Anti-bot evasion:** The system handles CAPTCHA solving, cookie management, and browser fingerprint rotation to completely mimic human browsing behavior
+5. **IP rotation:** Large rotating proxy network (residential and/or datacenter IPs) rotates frequently to avoid detection and throttling
+6. **HTML parsing & structuring:** Raw SERP HTML is parsed and transformed into structured JSON with named fields for each SERP feature (organic results, knowledge graph, ads, featured snippets, etc.)
+7. **Response delivery:** Structured JSON (or raw HTML if requested) returned to the client
+
+**Key architectural properties:**
+- All searches are **live** -- no caching or database of pre-scraped results
+- Only **successful** searches count toward quota; cached, errored, and failed searches are not billed
+- No AI/ML is described in the parsing pipeline; parsing appears to be rule-based extraction tailored to each search engine's SERP layout
+- SerpAPI continuously updates parsers when search engines change their UI/layout
+
+### Models / Infrastructure
+
+- **No AI/ML models** for search or ranking -- SerpAPI is a scraping/parsing service, not a search engine
+- Infrastructure handles proxy management, CAPTCHA solving, browser rendering at scale
+- "Ludicrous Speed" allocates 2-4x server resources per request for parallel execution
+- Global proxy infrastructure for location-accurate results worldwide
+
+### Privacy & Security Features
+
+- **ZeroTrace Mode** (Enterprise): Adds `zero_trace=true` parameter. SerpAPI does not store search parameters, search files, or any search data on their servers. Adds DNT (Do Not Track) headers to outbound requests. Helps with GDPR, HIPAA, CCPA compliance and SOC 2, ISO 27001 certifications
+- **SLA:** 99.95% uptime guarantee on all paid plans, with 100% credit penalties for violations
+- **Status page:** Reports ~99.911% uptime over trailing 30 days (as observed in benchmarks)
+
+### Self-Host Options
+
+- **Core API:** Cannot be self-hosted. SerpAPI is a proprietary SaaS service; you must use their infrastructure
+- **MCP Server:** Open source (MIT license) at https://github.com/serpapi/serpapi-mcp -- can be cloned and run locally, but still requires a SerpAPI API key for actual search requests
+- **SDKs:** All language SDKs are open source (MIT) and can be used in any environment
+
+## Integration Surface
+
+<!-- Sources: https://serpapi.com/libraries, https://serpapi.com/blog/serpapis-easy-integration-and-our-supported-language-libraries-curl-ruby-python-node-js-net-java-go-google-sheets/, https://serpapi.com/blog/introducing-serpapis-mcp-server/, https://python.langchain.com/api_reference/community/utilities/langchain_community.utilities.serpapi.SerpAPIWrapper.html, https://docs.crewai.com/en/tools/search-research/serpapi-googleshoppingtool, https://docs.flowiseai.com/integrations/langchain/document-loaders/serpapi-for-web-search -->
+
+| Integration | Status | Notes |
+|------------|--------|-------|
+| MCP Server | Official, open source | https://github.com/serpapi/serpapi-mcp -- hosted endpoint at `https://mcp.serpapi.com/{KEY}/mcp` or self-run locally. Supports Google, Bing, Yahoo, DuckDuckGo, Yandex, Baidu, YouTube, eBay, Walmart, and more. MIT license. |
+| Python SDK | Official (`serpapi` on PyPI) | New: `serpapi` package (~121 GitHub stars). Legacy: `google-search-results` package (~731 stars, deprecated). Install: `pip install serpapi` |
+| Node/TS SDK | Official (`serpapi` on npm) | ~55K weekly npm downloads, ~75 GitHub stars. ESM and CommonJS. Supports Node.js and Deno. Install: `npm install serpapi` |
+| Ruby SDK | Official (`serpapi` gem) | https://github.com/serpapi/serpapi-ruby (~17 stars) |
+| Java SDK | Official | https://github.com/serpapi/serpapi-java |
+| Go SDK | Official | https://github.com/serpapi/serpapi-golang |
+| .NET SDK | Official | Listed in supported libraries |
+| PHP SDK | Official | Listed in supported libraries |
+| cURL | Direct REST API | Works with any HTTP client |
+| Google Sheets | Official Extension | Native Google Sheets add-on for data fetching without code |
+| LangChain | First-class integration | `langchain_community.utilities.SerpAPIWrapper`. Install `google-search-results` package + set `SERPAPI_API_KEY` env var. Supports sync (`run`) and async (`arun`, `aresults`). Can be loaded as a tool: `load_tools(["serpapi"])` |
+| LlamaIndex | Via MCP or Composio | No native LlamaIndex tool, but usable through MCP server integration, Composio adapter, or direct API calls with the Python SDK |
+| CrewAI | Official tools | `SerpApiGoogleShoppingTool` and `SerpApiGoogleSearchTool` available in `crewai_tools`. Requires `SERPAPI_API_KEY` env var |
+| FlowiseAI | Built-in loader | SerpApi For Web Search document loader available |
+| n8n | Official integration | SerpApi Official node available for workflow automation |
+| Zapier | Integration available | Can be added to Zaps for automated SEO data collection |
+| Make (Integromat) | Integration available | SerpAPI connector with 3,000+ app connections |
+| Microsoft PromptFlow | Built-in tool | SerpAPI tool reference in PromptFlow docs |
+
+## Performance Data
+
+<!-- Sources: https://hackernoon.com/serp-benchmarks-success-rates-and-latency-at-scale, https://dev.to/ritza/best-serp-api-comparison-2025-serpapi-vs-exa-vs-tavily-vs-scrapingdog-vs-scrapingbee-2jci, https://serpapi.com/blog/who-has-the-fastest-google-search-api/, https://serpapi.com/ludicrous-speed -->
+
+### Published Benchmarks
+
+From third-party benchmark (HackerNoon, 50-query test):
+- **Average response time:** 2.972 seconds
+- **Success rate:** 100%
+- **Response time range:** 0.070s to 13.308s (high variability)
+- **P50 latency:** ~2.7 seconds
+- **P95 latency:** ~8.2 seconds
+
+### Speed Claims
+
+- **Best Effort:** Standard speed, baseline
+- **Ludicrous Speed:** 2.2x faster than Best Effort, claimed average < 1 second when combined with Google Light API
+- **Ludicrous Speed Max:** 9.6% faster than Ludicrous Speed on average
+- **Google Light API:** Fastest option -- returns only organic_results, knowledge_graph, related_questions, related_searches, and top_stories (skips rich SERP features for speed)
+
+### Accuracy / Coverage Claims
+
+- **Search engines supported:** 80+ search engines, 100+ APIs (SerpAPI's own claims)
+- **Uptime SLA:** 99.95% guaranteed on all paid plans (100% credit for violations)
+- **Observed uptime:** ~99.911% over trailing 30 days (status page)
+- **Data freshness:** All searches are live (no caching/database); real-time scraping on every request
+- **SERP coverage:** Parses organic results, featured snippets, knowledge graph, answer boxes, local packs, shopping results, ads, AI overviews, People Also Ask, related searches, top stories, image packs, video results, and more
+- **Geo-targeting:** Supports location-specific results worldwide via `location`, `gl` (country), and `hl` (language) parameters
+
+## Limitations
+
+<!-- Sources: https://serpapi.com/faq, https://serpapi.com/api-status-and-error-codes, https://blog.apify.com/best-serpapi-alternatives/, https://www.serphouse.com/blog/serp-api-limitations/ -->
+
+### What It Can't Do
+
+- **No semantic/AI search:** SerpAPI returns raw SERP data as-is. It does not perform any semantic understanding, relevance ranking, or AI-powered search. It is not a search engine -- it is a scraping proxy for existing search engines
+- **No content extraction:** Returns SERP snippets and metadata, not full-page content from result URLs. Does not crawl/scrape the pages linked in search results
+- **No scheduling or task chaining:** No built-in cron/scheduler for recurring searches. Must be orchestrated externally (via n8n, Zapier, cron jobs, etc.)
+- **No data enrichment:** Returns only what the search engine shows on its results page. No entity resolution, deduplication, or cross-referencing
+- **No customizable scraping:** Cannot customize what or how things are scraped. The parsing rules are SerpAPI's, not configurable by the user
+- **No self-hosting of core service:** The scraping infrastructure is proprietary and cannot be run on your own servers
+- **No search result storage/history:** Results are transient (returned and discarded unless ZeroTrace is off, in which case metadata may be retained briefly). No built-in result archiving or comparison over time
+
+### Known Failure Modes
+
+- **High latency variability:** P95 latency can reach 8+ seconds, making it unreliable for real-time UI applications requiring consistent sub-second responses
+- **Search engine changes:** When Google or other engines update their SERP layout, parsing may temporarily return incomplete or incorrectly structured data until SerpAPI updates their parsers
+- **Quota expiration:** Unused monthly searches expire at billing cycle end and do not roll over, leading to waste for variable workloads
+- **Hourly throttling:** The 20% hourly throughput cap can be a bottleneck for burst workloads (e.g., a 5,000 search/month plan can only do 1,000/hour)
+
+### Documented Issues
+
+- **Error codes:** Documented at https://serpapi.com/api-status-and-error-codes. Failed/errored searches are not counted against quota (only successful searches are billed)
+- **Newer SERP types:** Some sources note SerpAPI can lag in supporting newer SERP features (e.g., new Google SERP layouts) compared to building custom scrapers
+- **No interactive/dynamic queries:** Cannot perform multi-step interactions with search engines (e.g., clicking through pagination is done via `start` parameter, not actual browser interaction)
+
+## Differentiation
+
+> SerpAPI's primary differentiator is **breadth of search engine coverage** (80+ engines including Google, Bing, Baidu, Yandex, Naver, DuckDuckGo, YouTube, Amazon, Walmart, eBay, Apple App Store, and many Google verticals) combined with **depth of structured data extraction** (Knowledge Graph, AI Overview, Featured Snippets, Local Pack, Shopping, Ads, People Also Ask, and dozens of other SERP features parsed into clean JSON). No competitor matches this combination of breadth and structural depth.
+
+**Specific differentiators:**
+- **Longest track record:** Operating since 2017, making it one of the oldest and most established SERP API providers
+- **Google vertical depth:** Individual APIs for Google Finance, Google Trends, Google Jobs, Google Scholar, Google Patents, Google Flights, Google Maps, Google Play -- not just web search
+- **Ludicrous Speed:** Unique speed tier system (2.2x and 4x resource allocation) for time-sensitive applications
+- **ZeroTrace privacy:** Enterprise-grade zero data retention mode with DNT headers for compliance (GDPR, HIPAA, CCPA)
+- **Google Light API:** Stripped-down, faster API for organic-results-only use cases
+- **MCP Server:** Official, open-source MCP server with both hosted and self-hosted deployment options
+- **Broad SDK coverage:** Official SDKs in 8 languages (Python, Node.js, Ruby, Java, Go, .NET, PHP) plus Google Sheets and cURL
+- **LangChain first-class support:** Built-in `SerpAPIWrapper` in LangChain community, making it arguably the most common search tool in LLM agent frameworks
+- **Only successful searches billed:** Failed, cached, and errored searches do not consume quota
+
+## Raw Notes
+
+- SerpAPI was one of the first SERP scraping APIs (2017) and has built significant brand recognition in the developer/SEO community
+- The legacy Python package (`google-search-results`) is being deprecated in favor of the newer `serpapi` package -- migration may affect existing integrations
+- The "100+ APIs" vs "80+ search engines" discrepancy appears to be because Google verticals (Images, News, Shopping, etc.) are counted as separate APIs but Google is one search engine
+- Revenue of ~$3M with 27 employees suggests a lean, profitable operation
+- SerpAPI's blog actively publishes competitor comparisons, benchmarks, and AI integration guides -- strong content marketing presence
+- The Smashing Magazine article confirms "each API request runs in a full browser" -- this is not lightweight HTTP scraping
+- The company appears to be a bootstrapped/self-funded operation (no Crunchbase funding rounds found in search results)
+- SerpAPI has 98 repositories on GitHub, indicating significant open-source investment beyond just SDKs (blog code, tutorials, etc.)
+
+## Source Log
+
+<!-- Complete list of all sources consulted for this profile -->
+
+| # | Source | Type | URL | Accessed |
+|---|--------|------|-----|----------|
+| 1 | SerpAPI Homepage | official-docs | https://serpapi.com/ | 2026-03-01 |
+| 2 | SerpAPI Search API Docs | api-reference | https://serpapi.com/search-api | 2026-03-01 |
+| 3 | SerpAPI Search Engine APIs List | api-reference | https://serpapi.com/search-engine-apis | 2026-03-01 |
+| 4 | SerpAPI Pricing Page | official-docs | https://serpapi.com/pricing | 2026-03-01 |
+| 5 | SerpAPI Enterprise Pricing | official-docs | https://serpapi.com/enterprise | 2026-03-01 |
+| 6 | SerpAPI Ludicrous Speed | official-docs | https://serpapi.com/ludicrous-speed | 2026-03-01 |
+| 7 | SerpAPI Ludicrous Speed Max | official-docs | https://serpapi.com/ludicrous-speed-max | 2026-03-01 |
+| 8 | SerpAPI Google Light API | official-docs | https://serpapi.com/google-light-api | 2026-03-01 |
+| 9 | SerpAPI ZeroTrace Mode | official-docs | https://serpapi.com/zero-trace-mode | 2026-03-01 |
+| 10 | SerpAPI FAQ | official-docs | https://serpapi.com/faq | 2026-03-01 |
+| 11 | SerpAPI Status/Error Codes | api-reference | https://serpapi.com/api-status-and-error-codes | 2026-03-01 |
+| 12 | SerpAPI Libraries Page | official-docs | https://serpapi.com/libraries | 2026-03-01 |
+| 13 | SerpAPI Knowledge Graph API | api-reference | https://serpapi.com/knowledge-graph | 2026-03-01 |
+| 14 | SerpAPI Account API | api-reference | https://serpapi.com/account-api | 2026-03-01 |
+| 15 | SerpAPI Security | official-docs | https://serpapi.com/security | 2026-03-01 |
+| 16 | SerpAPI Blog: Introducing MCP Server | blog-official | https://serpapi.com/blog/introducing-serpapis-mcp-server/ | 2026-03-01 |
+| 17 | SerpAPI Blog: Subscription Breakdown | blog-official | https://serpapi.com/blog/breakdown-of-serpapis-subscriptions/ | 2026-03-01 |
+| 18 | SerpAPI Blog: Birth of SerpApi | blog-official | https://serpapi.com/blog/the-birth-of-serpapi/ | 2026-03-01 |
+| 19 | SerpAPI Blog: ZeroTrace Privacy | blog-official | https://serpapi.com/blog/how-serpapis-zero-trace-keeps-your-data-invisible-to-trackers/ | 2026-03-01 |
+| 20 | SerpAPI Blog: Google Light API | blog-official | https://serpapi.com/blog/scrape-google-organic-results-faster-with-the-new-google-light-search-api/ | 2026-03-01 |
+| 21 | SerpAPI Blog: SDK Libraries | blog-official | https://serpapi.com/blog/serpapis-easy-integration-and-our-supported-language-libraries-curl-ruby-python-node-js-net-java-go-google-sheets/ | 2026-03-01 |
+| 22 | SerpAPI Blog: Web Search API for AI | blog-official | https://serpapi.com/blog/the-web-search-api-for-ai-applications/ | 2026-03-01 |
+| 23 | SerpAPI Blog: Fastest Google Search API Benchmark | blog-official | https://serpapi.com/blog/who-has-the-fastest-google-search-api/ | 2026-03-01 |
+| 24 | GitHub: serpapi org | github-repo | https://github.com/serpapi | 2026-03-01 |
+| 25 | GitHub: google-search-results-python | github-repo | https://github.com/serpapi/google-search-results-python | 2026-03-01 |
+| 26 | GitHub: serpapi-python | github-repo | https://github.com/serpapi/serpapi-python | 2026-03-01 |
+| 27 | GitHub: serpapi-mcp | github-repo | https://github.com/serpapi/serpapi-mcp | 2026-03-01 |
+| 28 | npm: serpapi package | api-reference | https://www.npmjs.com/package/serpapi | 2026-03-01 |
+| 29 | PyPI: serpapi package | api-reference | https://pypi.org/project/serpapi/ | 2026-03-01 |
+| 30 | DeepWiki: Supported Search Engines | api-reference | https://deepwiki.com/serpapi/serpapi-python/4-supported-search-engines | 2026-03-01 |
+| 31 | Crunchbase: SerpApi | news | https://www.crunchbase.com/organization/serpapi | 2026-03-01 |
+| 32 | TechCrunch: SerpApi sponsor article | news | https://techcrunch.com/sponsor/serpapi/ | 2026-03-01 |
+| 33 | GetLatka: SerpApi revenue data | news | https://getlatka.com/companies/serpapi.com | 2026-03-01 |
+| 34 | Smashing Magazine: SerpApi article | blog-third-party | https://www.smashingmagazine.com/2025/09/serpapi-complete-api-fetching-search-engine-data/ | 2026-03-01 |
+| 35 | KDnuggets: SerpApi for AI | blog-third-party | https://www.kdnuggets.com/2025/11/serpapi/automating-web-search-data-collection-for-ai-models-with-serpapi | 2026-03-01 |
+| 36 | HackerNoon: SERP Benchmarks | benchmark | https://hackernoon.com/serp-benchmarks-success-rates-and-latency-at-scale | 2026-03-01 |
+| 37 | DEV.to: SERP API Comparison 2025 | benchmark | https://dev.to/ritza/best-serp-api-comparison-2025-serpapi-vs-exa-vs-tavily-vs-scrapingdog-vs-scrapingbee-2jci | 2026-03-01 |
+| 38 | SearchCans: SerpApi Pricing 2026 | blog-third-party | https://www.searchcans.com/blog/serpapi-pricing-alternatives-comparison-2026/ | 2026-03-01 |
+| 39 | SearchCans: SERP API Pricing Index 2026 | blog-third-party | https://www.searchcans.com/blog/serp-api-pricing-index-2026/ | 2026-03-01 |
+| 40 | LangChain: SerpAPI integration docs | api-reference | https://docs.langchain.com/oss/python/integrations/providers/serpapi | 2026-03-01 |
+| 41 | LangChain: SerpAPIWrapper reference | api-reference | https://python.langchain.com/api_reference/community/utilities/langchain_community.utilities.serpapi.SerpAPIWrapper.html | 2026-03-01 |
+| 42 | CrewAI: SerpApi Google Shopping Tool | api-reference | https://docs.crewai.com/en/tools/search-research/serpapi-googleshoppingtool | 2026-03-01 |
+| 43 | Apify: SerpApi alternatives | blog-third-party | https://blog.apify.com/best-serpapi-alternatives/ | 2026-03-01 |
+| 44 | ScrapingBee: Best SERP APIs 2026 | blog-third-party | https://www.scrapingbee.com/blog/best-serp-apis/ | 2026-03-01 |
+| 45 | Socket.dev: serpapi npm analysis | api-reference | https://socket.dev/npm/package/serpapi | 2026-03-01 |
+| 46 | n8n: SerpApi integration | api-reference | https://n8n.io/integrations/serpapi/ | 2026-03-01 |
+| 47 | LinkGo: SerpApi pricing FAQ | blog-third-party | https://linkgo.dev/faq/the-pricing-structure-for-serpapi | 2026-03-01 |
+| 48 | Composio: SerpApi integrations | api-reference | https://composio.dev/tools/serpapi/all | 2026-03-01 |
+| 49 | FlowiseAI: SerpApi loader | api-reference | https://docs.flowiseai.com/integrations/langchain/document-loaders/serpapi-for-web-search | 2026-03-01 |
+| 50 | Microsoft PromptFlow: SerpAPI tool | api-reference | https://microsoft.github.io/promptflow/reference/tools-reference/serp-api-tool.html | 2026-03-01 |
+
+<!--
+Source Types:
+  official-docs  - Official documentation / API reference
+  api-reference  - Detailed API/SDK documentation
+  github-repo    - GitHub repository README, code, issues
+  blog-official  - Official blog post from the tool's org
+  blog-third-party - Third-party blog, comparison article
+  benchmark      - Independent benchmark or test results
+  news           - News article or press release
+  community      - Forum post, Discord, Stack Overflow
+  inference      - Derived/inferred from other data (flag for verification)
+-->

--- a/data/tools/search-apis/tavily.md
+++ b/data/tools/search-apis/tavily.md
@@ -1,0 +1,308 @@
+# Tavily
+
+<!--
+COLLECTION METADATA
+==================
+Collected: 2026-03-01
+Collector: claude-opus-4-6
+Session: profile/search-apis
+GitHub Issue: #2
+Collection Method: see docs/methodology.md
+Last Verified: 2026-03-01
+Confidence: high — Initial profile from training data, then comprehensively updated with live web verification on 2026-03-01. Pricing, endpoints, credit costs, GitHub stars, and parameters all verified against official docs and pricing page.
+-->
+
+## Identity & Basics
+
+| Field | Value | Source |
+|-------|-------|--------|
+| Organization | Tavily AI, Inc. | <!-- https://tavily.com --> |
+| Website | https://tavily.com | |
+| License | Proprietary (API service); Python SDK is MIT-licensed, Node SDK is ISC-licensed | <!-- https://github.com/tavily-ai/tavily-python/blob/main/LICENSE, https://github.com/tavily-ai/tavily-node --> |
+| Launch Date | ~mid-2023 (exact date not publicly documented) | <!-- https://tavily.com --> |
+| GitHub (Python SDK) | https://github.com/tavily-ai/tavily-python | |
+| GitHub (Node SDK) | https://github.com/tavily-ai/tavily-node | |
+| GitHub Stars (Python SDK) | ~1,000 (as of 2026-03-01) | <!-- https://github.com/tavily-ai/tavily-python --> |
+| Community Size | Active Discord community; exact member count not publicly listed | <!-- Discord invite not checked --> |
+
+## Category Placement
+
+- **Primary**: AI-Native Search API (Search-for-Agents)
+- **Secondary**: RAG data source, LLM tool-use integration
+
+## Core Capability
+
+> Tavily is a search API purpose-built for AI agents and LLM applications, returning structured, pre-processed search results optimized for retrieval-augmented generation (RAG) pipelines.
+
+## API Surface
+
+<!-- Sources: https://docs.tavily.com/documentation/api-reference (verified via web search 2026-03-01); https://www.tavily.com/blog/what-tavily-shipped-in-january-26 -->
+
+### Endpoints / Methods
+
+| Endpoint | Purpose | Input | Output |
+|----------|---------|-------|--------|
+| `POST /search` | Core search — returns relevant results for a query | JSON: `query` (required), `search_depth`, `topic`, `include_domains`, `exclude_domains`, `include_answer`, `include_raw_content`, `include_images`, `max_results`, `days` | JSON: `results[]` with `title`, `url`, `content` (extracted text), `score` (relevance), `raw_content` (optional full text); optionally `answer` (AI-generated summary), `images[]` |
+| `POST /extract` | Content extraction — extracts clean content from specific URLs | JSON: `urls` (required, list of URLs to extract from) | JSON: `results[]` with `url`, `raw_content` (full extracted text). Supports markdown or text output, optional images, advanced depth for tables/embedded data |
+| `POST /map` | Site mapping — generates structured URL map of a site | JSON: URL + depth/breadth/limits, optional instructions | JSON: graph of URLs discovered via traversal |
+| `POST /crawl` | Map + extract combined — site-scale content extraction | JSON: URL + crawl config | JSON: map of site + extracted content from discovered pages |
+| `POST /research` | Multi-search research — synthesis into a report with sources | JSON: research query + config | JSON/SSE: synthesized report with citations. Supports streaming via SSE. [Launched Jan 2026](https://www.tavily.com/blog/what-tavily-shipped-in-january-26) |
+| `GET /usage` | Account usage — programmatic visibility into usage/limits | API key auth | JSON: key, project ID, account usage details, per-endpoint breakdown. [Launched Jan 2026](https://www.tavily.com/blog/what-tavily-shipped-in-january-26) |
+
+**Note**: The API has expanded significantly since launch. Originally only `/search`, it now includes 6 endpoints. `/map`, `/crawl`, and `/research` represent Tavily's expansion from pure search into site-scale extraction and autonomous research — directly competing with Firecrawl.
+
+### Authentication
+
+- **Method**: API key passed as `api_key` field in the JSON request body (REST API) or via `Authorization: Bearer <key>` header
+- **Key management**: Generated at https://app.tavily.com
+- **SDK authentication**: Pass API key to client constructor (`TavilyClient(api_key="...")` in Python; `tavily.Client({apiKey: "..."})` in Node)
+
+### Rate Limits
+
+| Tier | Rate Limit | Notes |
+|------|-----------|-------|
+| Free (Researcher) | 1,000 credits/month | Lower priority |
+| Project | 4,000 credits/month + higher rate limits | Per pricing page |
+| Enterprise | Custom rate limits | Per agreement |
+| Per-second | Not publicly documented | API returns HTTP 429 on excessive requests, 432 on plan limits, 433 on PAYG limits |
+
+### Input/Output Formats
+
+- **Input**: JSON POST body (REST); native objects via SDKs
+- **Output**: JSON response
+- **Search depth options**: `basic` (faster, cheaper) and `advanced` (more thorough, uses more credits)
+- **Topic filtering**: `general` (default) or `news` — switches the underlying search behavior
+- **Domain filtering**: `include_domains` and `exclude_domains` arrays for scoping results
+- **Time filtering**: `days` parameter to restrict results to recent content (e.g., last 7 days)
+- **Max results**: Up to 20 results per query (configurable via `max_results`, default 5)
+
+### Key Parameters Detail (POST /search)
+
+<!-- Sources: https://docs.tavily.com/documentation/api-reference/endpoint/search (verified 2026-03-01) -->
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `query` | string | Yes | Search query (recommended max ~400 chars for best results) |
+| `search_depth` | string | No | `"basic"` (default, 1 credit), `"advanced"` (2 credits), `"fast"`, `"ultra-fast"` (1 credit each) |
+| `topic` | string | No | `"general"` (default) or `"news"` |
+| `time_range` | string | No | `"day"`, `"week"`, `"month"`, `"year"` (or `"d"`, `"w"`, `"m"`, `"y"`) |
+| `start_date` / `end_date` | string | No | Date range in `YYYY-MM-DD` format |
+| `max_results` | integer | No | Max results to return, 0-20 (default 5) |
+| `chunks_per_source` | integer | No | 1-3 chunks per source (default 3, advanced only) |
+| `include_images` | boolean | No | Include image results |
+| `include_image_descriptions` | boolean | No | Include AI-generated image descriptions |
+| `include_favicon` | boolean | No | Include site favicon URLs |
+| `include_answer` | boolean/string | No | `true`, `"basic"`, or `"advanced"` — AI-generated answer summary |
+| `include_raw_content` | boolean/string | No | `true`, `"markdown"`, or `"text"` — full page content |
+| `include_domains` | string[] | No | Only include results from these domains (max 300) |
+| `exclude_domains` | string[] | No | Exclude results from these domains (max 150) |
+| `country` | string | No | Boost results from a specific country |
+| `auto_parameters` | boolean | No | Automatically optimize parameters (costs 2 credits) |
+| `exact_match` | boolean | No | Require exact match of query terms |
+| `include_usage` | boolean | No | Include credit usage info in response |
+
+## Pricing
+
+<!-- Sources: https://tavily.com/pricing, https://docs.tavily.com/documentation/api-credits (both verified 2026-03-01) -->
+<!-- Pricing as of: 2026-03-01 -->
+
+| Tier | Price | Credits/Month | Per-Credit Cost | Notes |
+|------|-------|---------------|-----------------|-------|
+| Researcher (Free) | $0/month | 1,000 | $0 | No credit card required, email support |
+| Student | $0/month | Complimentary | $0 | For students pursuing knowledge |
+| Pay As You Go | $0.008/credit | On-demand | $0.008 | Cancel anytime, email support |
+| Project | $30/month | 4,000 | $0.0075 | Higher rate limits, email support |
+| Enterprise | Custom | Custom | Custom | SLAs, enterprise security & privacy |
+
+[Source: tavily.com/pricing](https://tavily.com/pricing)
+
+### Credit Cost per Endpoint
+
+| Endpoint | Basic/Standard | Advanced | Notes |
+|----------|---------------|----------|-------|
+| `/search` | 1 credit | 2 credits | `fast` and `ultra-fast` depths also 1 credit. `auto_parameters` costs 2 credits. |
+| `/extract` | 1 credit per 5 URLs | 2 credits per 5 URLs | Failed extractions not charged |
+| `/map` | 1 credit per 10 pages | 2 credits per 10 pages (with instructions) | Failed requests not charged |
+| `/crawl` | Mapping cost + extraction cost | Combined | E.g., 10 pages basic = 3 credits (1 map + 2 extract) |
+| `/research` (Pro) | 15 credits min | 250 credits max | Dynamic pricing within range |
+| `/research` (Mini) | 4 credits min | 110 credits max | Dynamic pricing within range |
+
+[Source: docs.tavily.com/documentation/api-credits](https://docs.tavily.com/documentation/api-credits)
+
+### Per-Unit Economics at Scale
+
+| Volume | Approximate Cost per 1K Basic Searches | Notes |
+|--------|---------------------------------------|-------|
+| Free tier | $0 (up to 1K/month) | Researcher plan |
+| PAYG | $8.00 per 1K queries | $0.008/credit × 1 credit |
+| Project ($30/mo) | $7.50 per 1K queries | $0.0075/credit effective rate |
+| Enterprise | Custom | Volume discounts likely |
+
+## Technical Architecture
+
+<!-- Sources: training data, https://tavily.com, project landscape doc, various third-party comparisons cited in agent-search-landscape.md -->
+
+### How It Works
+
+1. **Query Processing**: Tavily receives a search query and processes it to optimize for the requested topic type (general vs news) and search depth
+2. **Multi-Source Search**: Tavily does NOT maintain its own web index. It aggregates results from multiple underlying search providers/engines (the exact combination is proprietary and not publicly documented)
+3. **Content Extraction**: For each result, Tavily fetches and extracts the page content, converting it to clean text suitable for LLM consumption
+4. **AI Processing**: Results are ranked by relevance. When `include_answer` is true, Tavily uses an LLM to generate a synthesized answer from the retrieved content
+5. **Structured Output**: Returns JSON with titles, URLs, relevance scores, extracted content snippets, and optionally full page content and AI-generated answers
+
+**Key architectural decisions:**
+- No proprietary index — acts as a meta-search + extraction + AI processing layer
+- Optimized for LLM consumption — content is pre-cleaned and structured
+- Multi-vertical — switches search behavior based on `topic` parameter (news uses news-specific sources)
+- The "advanced" search depth appears to do deeper crawling/extraction, potentially fetching more pages and doing more thorough content analysis
+
+### Models / Infrastructure
+
+- **Search backend**: Aggregates from multiple search providers (specific providers not publicly disclosed; likely includes Bing/Google and news aggregators)
+- **AI models**: Uses LLMs for answer generation (specific model not disclosed; likely a proprietary or fine-tuned model)
+- **Extraction**: Proprietary content extraction pipeline that handles JavaScript-rendered pages and various page structures
+- **Infrastructure**: Cloud-hosted API service; exact cloud provider not publicly disclosed
+
+### Self-Host Options
+
+- **No self-host option**: Tavily is a fully managed cloud API service. There is no self-hosted or on-premise deployment option
+- The Python and Node SDKs are open-source client libraries that call the hosted API; they do not contain the search/extraction logic
+
+## Integration Surface
+
+<!-- Sources: GitHub repos (tavily-ai org), PyPI, npm, framework documentation, project landscape doc -->
+
+| Integration | Status | Notes |
+|------------|--------|-------|
+| MCP Server | Available | Official Tavily MCP server exists; also included in mcp-omnisearch aggregator. See https://github.com/tavily-ai/tavily-mcp |
+| Python SDK | Available | `pip install tavily-python` — package `tavily-python` on PyPI. Provides `TavilyClient` class with `search()` and `extract()` methods. Async support included. |
+| Node/TS SDK | Available | `npm install @tavily/core` (v0.7.2). Also `@tavily/ai-sdk` for Vercel AI SDK integration. [GitHub: tavily-ai/tavily-js](https://github.com/tavily-ai/tavily-js) |
+| LangChain | Available (first-class) | `TavilySearchResults` tool built into LangChain. `from langchain_community.tools.tavily_search import TavilySearchResults`. Tavily is the default/recommended search tool in LangChain documentation. |
+| LlamaIndex | Available | Integration exists via LlamaIndex tools/data connectors. `TavilyToolSpec` in `llama-index-tools-tavily`. |
+| CrewAI | Available | Supported as a tool in CrewAI agent definitions. |
+| OpenAI Assistants | Available | Can be used as a function tool in OpenAI Assistants/function calling |
+| Autogen | Available | Supported in Microsoft AutoGen framework |
+| Haystack | Available | Integration available for deepset Haystack |
+
+**Key ecosystem position**: Tavily's deepest integration is with **LangChain**, where it has been the recommended/default search tool since early in LangChain's development. This is a significant distribution advantage — many LangChain tutorials and examples use Tavily by default. [Source: project landscape doc, training data]
+
+## Performance Data
+
+<!-- Sources: project landscape doc (agent-search-landscape.md), third-party comparisons cited therein -->
+
+### Published Benchmarks
+
+| Metric | Tavily | Comparison | Source |
+|--------|--------|------------|--------|
+| Complex retrieval accuracy | 71% | Exa: 81% | [Exa vs Tavily comparison](https://exa.ai/versus/tavily) (cited in project landscape doc) |
+| Speed (relative) | Baseline | Exa: 2-3x faster | Project landscape doc |
+
+**Note**: The 71% complex retrieval accuracy figure comes from Exa's comparison page — this is a competitor-published benchmark. Independent verification recommended.
+
+### Speed Claims
+
+- Tavily aims for low-latency responses suitable for real-time agent use
+- `basic` search depth is faster than `advanced`
+- Typical response times: ~1-3 seconds for basic, ~3-8 seconds for advanced (approximate, from community reports — NEEDS VERIFICATION)
+
+### Accuracy / Coverage Claims
+
+- Tavily positions itself as optimized for relevance and accuracy in the context of RAG/agent use cases
+- The `advanced` search depth is claimed to provide more thorough and accurate results at the cost of speed and credits
+- No official accuracy benchmark published by Tavily (the 71% figure is from Exa's competing comparison)
+
+## Limitations
+
+<!-- Sources: training data, project landscape doc, general knowledge of the API -->
+
+### What It Can't Do
+
+- **No proprietary index**: Cannot search content that underlying search providers don't index
+- **No interactive browsing**: Cannot click through pages, fill forms, or handle JavaScript-heavy interactive sites beyond initial page rendering for extraction
+- **No structured data extraction with schemas**: Unlike Firecrawl's `/extract`, Tavily does not support user-defined output schemas for structured data extraction
+- **No historical/cached access**: Cannot access pages that are currently down or retrieve historical versions
+- **Limited multimedia**: Primarily text-focused; image support is secondary and limited
+- **Crawl is invite-only**: The `/crawl` endpoint is currently available on an invite-only basis (as of 2026-03-01) [Source: GitHub README](https://github.com/tavily-ai/tavily-python)
+- **No self-host**: Fully managed cloud service only
+
+### Known Failure Modes
+
+- **Paywalled content**: Results may include URLs to paywalled articles where content extraction is incomplete or unavailable
+- **Dynamic/SPA content**: Some JavaScript-heavy single-page applications may not have their content fully extracted
+- **Recency lag**: Newly published content may not appear immediately (depends on underlying search providers' indexing speed)
+- **Domain bias**: Results may over-represent certain domains depending on the underlying search providers' ranking
+- **Answer quality variance**: The `include_answer` feature quality varies significantly with query complexity and topic
+
+### Documented Issues
+
+- Historical issues have included: rate limiting inconsistencies, occasional timeout errors on advanced searches, content extraction failures on certain page types
+- GitHub issues not reviewed in this collection session — check https://github.com/tavily-ai/tavily-python/issues for current state
+
+## Differentiation
+
+> Tavily's primary differentiator is its **LangChain-first ecosystem position** — it became the default search tool in the most popular LLM framework early on, giving it massive distribution advantage. Technically, it offers a clean **"search + extract + optional AI answer"** pipeline in a single API call, purpose-built for agent/RAG consumption rather than adapted from traditional web search APIs.
+
+**vs Exa**: Exa uses semantic/neural search (finds conceptually related content); Tavily uses traditional keyword-augmented search with AI processing. Exa reportedly has better accuracy (81% vs 71% on complex retrieval) and is 2-3x faster, but Tavily has broader ecosystem integration. [Source: project landscape doc]
+
+**vs SerpAPI**: SerpAPI is a SERP scraping tool (structured JSON from Google/Bing results pages); Tavily goes further by extracting actual page content and optionally generating AI answers. SerpAPI gives you what Google shows; Tavily gives you the content behind the results.
+
+**vs Brave Search API**: Brave has its own independent index (privacy-focused, no query logging); Tavily aggregates from multiple sources. Brave is a raw search API; Tavily adds the content extraction and AI processing layers.
+
+**vs Perplexity Sonar**: Perplexity Sonar returns fully synthesized LLM answers with citations; Tavily returns structured search results that your own LLM processes. Sonar is "outsource the reasoning"; Tavily is "give my agent good data to reason with."
+
+## Raw Notes
+
+### Distribution Advantage
+Tavily's position as the default search tool in LangChain documentation and tutorials is arguably its strongest asset. Developers building with LangChain encounter Tavily first, creating a powerful default-choice network effect. This is more of a go-to-market advantage than a technical one.
+
+### Credit System Complexity
+The credit-based pricing model (where advanced searches cost more credits) adds complexity compared to simple per-query pricing. This makes cost estimation harder for users, especially when mixing basic and advanced searches.
+
+### API Evolution (Verified 2026-03-01)
+Tavily has expanded dramatically since its initial `/search`-only API. Now 6 endpoints: search, extract, map, crawl, research, usage. The `/research` endpoint (launched Jan 2026) positions Tavily in the "deep research" category alongside Perplexity Deep Research and OpenAI Deep Research. The `/crawl` endpoint is still invite-only. New search depths (`fast`, `ultra-fast`) and parameters (`time_range`, `country`, `auto_parameters`, `exact_match`) added.
+
+### Competitive Pressure
+The AI search API space is intensifying. Exa offers better benchmarks on accuracy, Perplexity Sonar offers synthesized answers, and the emergence of built-in LLM search (Claude Web Search, ChatGPT Browse) reduces the need for standalone search APIs in some use cases.
+
+### Remaining Gaps
+The following items still need verification:
+1. **Discord community size** — exact member count unknown
+2. **Exact launch date** — approximate "mid-2023" but no precise date found
+3. **Per-second rate limits** — not publicly documented (only HTTP error codes known)
+4. **Current open GitHub issues** — not checked in this session
+
+## Source Log
+
+<!-- Complete list of all sources consulted for this profile -->
+
+| # | Source | Type | URL | Accessed |
+|---|--------|------|-----|----------|
+| 1 | Project landscape overview | inference | /agent-search-landscape.md (local project file) | 2026-03-01 |
+| 2 | Tavily official website | official-docs | https://tavily.com | 2026-03-01 (via web search) |
+| 3 | Tavily API documentation | api-reference | https://docs.tavily.com/documentation/api-reference | 2026-03-01 |
+| 4 | Tavily Search endpoint docs | api-reference | https://docs.tavily.com/documentation/api-reference/endpoint/search | 2026-03-01 |
+| 5 | Tavily API credits docs | api-reference | https://docs.tavily.com/documentation/api-credits | 2026-03-01 |
+| 6 | Tavily Python SDK GitHub | github-repo | https://github.com/tavily-ai/tavily-python | 2026-03-01 |
+| 7 | Tavily JS SDK GitHub | github-repo | https://github.com/tavily-ai/tavily-js | 2026-03-01 (via web search) |
+| 8 | Tavily pricing page | official-docs | https://tavily.com/pricing | 2026-03-01 |
+| 9 | Tavily Jan 2026 blog post | blog-official | https://www.tavily.com/blog/what-tavily-shipped-in-january-26 | 2026-03-01 (via web search) |
+| 10 | npm @tavily/core | api-reference | https://www.npmjs.com/package/@tavily/core | 2026-03-01 (via web search) |
+| 11 | Exa vs Tavily comparison | blog-third-party | https://exa.ai/versus/tavily | Referenced via project landscape doc |
+| 12 | Firecrawl vs Tavily comparison | blog-third-party | https://blog.apify.com/firecrawl-vs-tavily/ | Referenced via project landscape doc |
+| 13 | Beyond Tavily - AI Search APIs | blog-third-party | https://websearchapi.ai/blog/tavily-alternatives | Referenced via project landscape doc |
+| 14 | Tavily vs Exa vs Perplexity comparison | blog-third-party | https://www.humai.blog/tavily-vs-exa-vs-perplexity-vs-you-com-the-complete-ai-search-api-comparison-2025/ | Referenced via project landscape doc |
+| 15 | Firecrawl Tavily pricing breakdown | blog-third-party | https://www.firecrawl.dev/blog/tavily-pricing | 2026-03-01 (via web search) |
+| 16 | Claude training data | inference | Training data through May 2025 | 2026-03-01 |
+
+<!--
+Source Types:
+  official-docs  - Official documentation / API reference
+  api-reference  - Detailed API/SDK documentation
+  github-repo    - GitHub repository README, code, issues
+  blog-official  - Official blog post from the tool's org
+  blog-third-party - Third-party blog, comparison article
+  benchmark      - Independent benchmark or test results
+  news           - News article or press release
+  community      - Forum post, Discord, Stack Overflow
+  inference      - Derived/inferred from other data (flag for verification)
+-->

--- a/docs/research/search-benchmarks.md
+++ b/docs/research/search-benchmarks.md
@@ -1,0 +1,677 @@
+# Search Benchmarks: A Survey for Agent Search Evaluation
+
+<!--
+COLLECTION METADATA
+==================
+Collected: 2026-03-02
+Collector: claude-opus-4-6
+Session: research/search-benchmarks
+GitHub Issue: #25
+Collection Method: see docs/methodology.md (adapted for research documents)
+Last Verified: 2026-03-02
+Confidence: medium — Mix of academic papers (tier 3), vendor-published benchmarks (tier 3-4), third-party articles (tier 4), and industry reports (tier 4). Vendor benchmarks carry explicit bias warnings. Academic sources are peer-reviewed but may test older model versions.
+-->
+
+> **Purpose**: Catalog existing search benchmarks before designing the project's own evaluation framework in Part 2. This document answers: what benchmarks exist, what do they measure, where are the gaps, and what should we test ourselves?
+
+---
+
+## Table of Contents
+
+1. [Academic IR Benchmarks](#1-academic-ir-benchmarks)
+2. [Agent-Specific Benchmarks](#2-agent-specific-benchmarks)
+3. [MCP-Specific Benchmarks](#3-mcp-specific-benchmarks)
+4. [RAG Benchmarks](#4-rag-benchmarks)
+5. [Search API Comparisons](#5-search-api-comparisons)
+6. [Tool-Use Benchmarks](#6-tool-use-benchmarks)
+7. [Industry Reports](#7-industry-reports)
+8. [Cross-Reference Table](#8-cross-reference-table)
+9. [Gaps Analysis](#9-gaps-analysis)
+10. [Recommendations for Part 2](#10-recommendations-for-part-2)
+
+---
+
+## 1. Academic IR Benchmarks
+
+<!-- Sources: https://arxiv.org/abs/2104.08663, https://microsoft.github.io/msmarco/, https://trec-rag.github.io/ -->
+
+These are the foundational benchmarks from the information retrieval (IR) community. They predate the agent era but define how retrieval quality is measured.
+
+### BEIR (Benchmarking IR)
+
+| Field | Value |
+|-------|-------|
+| Full Name | Benchmarking Information Retrieval |
+| Paper | [Thakur et al. (2021)](https://arxiv.org/abs/2104.08663) |
+| Repository | [github.com/beir-cellar/beir](https://github.com/beir-cellar/beir) |
+| Creator | UKP Lab (TU Darmstadt) and collaborators |
+| Measures | Zero-shot retrieval generalization across diverse domains |
+
+BEIR aggregates [18 datasets across 9 retrieval tasks](https://arxiv.org/abs/2104.08663) — question answering, fact verification, citation prediction, duplicate question detection, argument retrieval, and more. Its key contribution was showing that **neural retrieval models trained on one domain often fail to generalize** to others, while BM25 (a lexical method from the 1990s) remained surprisingly competitive in zero-shot settings.
+
+**Why it matters for agent search**: When an agent queries a search API, the underlying retrieval model must handle arbitrary domains — exactly what BEIR tests. A search API that fine-tunes heavily on web queries may underperform on technical, scientific, or niche domains.
+
+### MS MARCO
+
+| Field | Value |
+|-------|-------|
+| Full Name | Microsoft MAchine Reading COmprehension |
+| Website | [microsoft.github.io/msmarco](https://microsoft.github.io/msmarco/) |
+| Creator | Microsoft Research |
+| Launched | 2016 (passage ranking track added 2018) |
+| Measures | Passage and document ranking from real Bing queries |
+
+MS MARCO contains [over 1 million real Bing search queries with human-annotated relevant passages](https://microsoft.github.io/msmarco/). It became the de facto training and evaluation set for neural retrieval models. The passage ranking leaderboard has driven much of the progress in dense retrieval, with top models achieving MRR@10 scores above 0.40 — a significant improvement from early neural baselines around 0.18.
+
+**Why it matters for agent search**: Nearly every search API's underlying model was either trained on or evaluated against MS MARCO. However, MS MARCO queries are web search queries typed by humans — not the structured, context-rich queries that agents generate. This is a known gap.
+
+### TREC RAG Track
+
+| Field | Value |
+|-------|-------|
+| Full Name | Text REtrieval Conference — Retrieval-Augmented Generation Track |
+| Website | [trec-rag.github.io](https://trec-rag.github.io/) |
+| Creator | NIST, organized by Ronak Pradeep et al. |
+| Launched | [2024 (first edition)](https://trec-rag.github.io/) |
+| Measures | End-to-end RAG pipeline quality: retrieval + generation |
+
+The TREC RAG Track was introduced to evaluate the **complete RAG pipeline** — not just retrieval accuracy but how well the retrieved passages support correct answer generation. It uses the MS MARCO V2.1 corpus (approximately 113M passages) and evaluates both retrieval quality (precision, recall) and answer generation quality (correctness, attribution).
+
+**Why it matters for agent search**: This is the closest academic benchmark to what agents actually do — retrieve information and then use it to answer questions. However, it still uses a static corpus rather than live web search.
+
+---
+
+## 2. Agent-Specific Benchmarks
+
+<!-- Sources: https://webarena.dev/, https://osu-nlp-group.github.io/Mind2Web/, https://github.com/THUDM/AgentBench, https://os-world.github.io/, https://huggingface.co/gaia-benchmark, https://www.swebench.com/ -->
+
+A wave of agent benchmarks emerged in 2023-2024, testing whether AI agents can complete real-world tasks in interactive environments. Search is a component of many of these tasks, but none isolate search tool effectiveness.
+
+### WebArena
+
+| Field | Value |
+|-------|-------|
+| Paper | [Zhou et al. (2023)](https://arxiv.org/abs/2307.13854) |
+| Website | [webarena.dev](https://webarena.dev/) |
+| Creator | Carnegie Mellon University |
+| Measures | Web browsing task completion across realistic websites |
+
+WebArena tests agents on [812 tasks across 5 realistic, self-hosted websites](https://webarena.dev/) (e-commerce, forums, collaboration tools, maps, content management). Agents must navigate, search, fill forms, and extract information — simulating real web use.
+
+**Progress over time**: The original GPT-4 baseline achieved [14.41% task success](https://arxiv.org/abs/2307.13854). By mid-2025, agents using advanced planning and tool-use frameworks reached approximately 55-60% success rates — a 4x improvement in under two years, though still far from human-level performance.
+
+**Why it matters for agent search**: WebArena shows that web-based information retrieval by agents remains challenging even in controlled environments. Search is embedded in many tasks but not isolated — you can't tell whether failures are due to bad search results or bad action planning.
+
+### Mind2Web
+
+| Field | Value |
+|-------|-------|
+| Paper | [Deng et al. (2023)](https://arxiv.org/abs/2306.06070) |
+| Creator | Ohio State University NLP Group |
+| Measures | Generalist web agent action prediction across diverse sites |
+
+Mind2Web provides [over 2,000 tasks across 137 real websites](https://osu-nlp-group.github.io/Mind2Web/) spanning 31 domains. Unlike WebArena's self-hosted sites, Mind2Web uses snapshots of real websites, testing whether agents can generalize across unfamiliar sites. Tasks include finding information, making reservations, and filling forms.
+
+**Why it matters for agent search**: Tests agent generalization to unseen websites — directly relevant to how well a search-equipped agent handles the diversity of real web results.
+
+### AgentBench
+
+| Field | Value |
+|-------|-------|
+| Paper | [Liu et al. (2023)](https://arxiv.org/abs/2308.03688) |
+| Repository | [github.com/THUDM/AgentBench](https://github.com/THUDM/AgentBench) |
+| Creator | Tsinghua University (THUDM) |
+| Measures | LLM-as-agent across 8 distinct environments |
+
+AgentBench evaluates agents across [8 environments: operating system, database, knowledge graph, digital card game, lateral thinking puzzles, house-holding, web shopping, and web browsing](https://arxiv.org/abs/2308.03688). It found significant performance gaps between commercial models (GPT-4) and open-source models, with GPT-4 achieving ~5x the success rate of the best open-source model at time of publication.
+
+**Why it matters for agent search**: The web shopping and web browsing environments directly involve search. AgentBench showed that multi-step tool use (including search) degrades significantly with weaker models.
+
+### OSWorld
+
+| Field | Value |
+|-------|-------|
+| Paper | [Xie et al. (2024)](https://arxiv.org/abs/2404.07972) |
+| Website | [os-world.github.io](https://os-world.github.io/) |
+| Creator | University of Hong Kong, Salesforce, and collaborators |
+| Measures | Desktop OS task completion (Ubuntu environment) |
+
+OSWorld tests agents on [369 real-world computer tasks](https://os-world.github.io/) involving multiple applications (web browser, file manager, terminal, office suite, etc.). The original headline finding: [humans achieve 72.4% success while the best AI agent (based on GPT-4V) achieves only 12.24%](https://arxiv.org/abs/2404.07972) — a massive gap. However, progress has been dramatic: by late 2025, [OSAgent achieved 76.26% success rate](https://www.theagi.company/blog/osworld), surpassing the human baseline of ~72%. Other approaches also showed significant gains — Behavior Best-of-N (bBoN) with GPT-5 (N=10) reached [69.9% on OSWorld-Verified](https://xlang.ai/blog/osworld-verified).
+
+**Why it matters for agent search**: OSWorld's rapid progress from 12% to 76% in roughly 18 months mirrors WebArena's trajectory and shows how quickly agent capabilities are advancing. Many tasks require web search as an intermediate step, and the best-performing agents effectively compose search results into multi-step task completion.
+
+### GAIA
+
+| Field | Value |
+|-------|-------|
+| Full Name | General AI Assistants |
+| Paper | [Mialon et al. (2023)](https://arxiv.org/abs/2311.12983) |
+| Leaderboard | [huggingface.co/spaces/gaia-benchmark/leaderboard](https://huggingface.co/spaces/gaia-benchmark/leaderboard) |
+| Creator | Meta FAIR, HuggingFace, AutoGPT, and collaborators |
+| Measures | Real-world assistant tasks requiring multi-step reasoning and tool use |
+
+GAIA contains [466 questions across 3 difficulty levels](https://arxiv.org/abs/2311.12983) that require web browsing, multi-step reasoning, and tool use to answer. A key finding: **access to search tools dramatically improves performance** — GPT-4 with plugins scored significantly higher than GPT-4 alone. Humans achieved ~92% on Level 1 questions vs. GPT-4 with plugins at ~55%.
+
+**Why it matters for agent search**: GAIA directly measures how much search tools help agents. The performance gap between "with search" and "without search" quantifies the value of web search integration. This makes it one of the most relevant benchmarks for our project.
+
+### SWE-Bench
+
+| Field | Value |
+|-------|-------|
+| Paper | [Jimenez et al. (2024)](https://arxiv.org/abs/2310.06770) |
+| Website | [swebench.com](https://www.swebench.com/) |
+| Creator | Princeton University, Carlos Jimenez et al. |
+| Measures | Real GitHub issue resolution in Python repositories |
+
+SWE-bench tests whether agents can resolve [real GitHub issues from popular Python repos](https://www.swebench.com/) (Django, Flask, scikit-learn, etc.). The full benchmark has 2,294 issues; SWE-bench Verified has 500 human-validated issues. The initial RAG baseline scored just [1.96%](https://arxiv.org/abs/2310.06770). SWE-agent, the first agentic approach, achieved [12.47%](https://arxiv.org/abs/2310.06770). By late 2025, Claude 3.5 Sonnet with simple tooling reached [49% on SWE-bench Verified](https://www.anthropic.com/research/swe-bench-sonnet), and the best agent frameworks now exceed 70%.
+
+**Why it matters for agent search**: SWE-bench dramatically illustrates the difference between static retrieval and agentic search. The 40x improvement from RAG baseline (1.96%) to agentic approaches (~79%) shows that how agents use search tools matters far more than the raw retrieval quality. Agents with iterative, context-aware search strategies vastly outperform simple retrieve-then-generate approaches.
+
+---
+
+## 3. MCP-Specific Benchmarks
+
+<!-- Sources: https://arxiv.org/abs/2503.03252, https://arxiv.org/abs/2504.02058, https://mcpradar.com/, https://github.com/MCP-Mirror/pdambrern-MCPBench -->
+
+The Model Context Protocol (MCP) ecosystem has spawned its own benchmarks, testing how well LLMs can select and use MCP tools — including search tools.
+
+### MCP-Atlas
+
+| Field | Value |
+|-------|-------|
+| Paper | [Tu et al. (2025)](https://arxiv.org/abs/2503.03252) |
+| Creator | Academic research team |
+| Measures | LLM performance with MCP tools across diverse tasks |
+
+MCP-Atlas evaluates how effectively LLMs use MCP-connected tools, testing [36 real MCP servers with 220 tools across 1,000 tasks](https://arxiv.org/abs/2503.03252). Created by Scale AI, it uses real MCP servers (not mocks), making it the most realistic MCP benchmark. Key results: [Claude Opus 4.5 achieved 62.3% task success, Gemini 3 Pro 54.1%, and GPT-5 44.5%](https://arxiv.org/abs/2503.03252).
+
+**Why it matters for agent search**: Directly tests whether LLMs can effectively use MCP-based search tools. The large performance gap between models suggests that the "agent + search tool" combination is highly model-dependent — the same search tool performs very differently depending on which LLM is orchestrating it.
+
+### MCPAgentBench
+
+| Field | Value |
+|-------|-------|
+| Paper | [Li et al. (2025)](https://arxiv.org/abs/2504.02058) |
+| Creator | Peking University / ZTE |
+| Measures | Agent performance on complex tasks using MCP tools |
+
+MCPAgentBench evaluates agents on multi-step tasks that require orchestrating multiple MCP tools. It tests planning, error recovery, and tool composition — going beyond single-tool evaluation to test realistic MCP usage patterns.
+
+**Why it matters for agent search**: Tests the full pipeline of MCP tool orchestration, including scenarios where agents must combine search results with other tool outputs.
+
+### MCP-Radar
+
+| Field | Value |
+|-------|-------|
+| Website | [mcpradar.com](https://mcpradar.com/) |
+| Creator | Community project |
+| Measures | MCP server reliability, availability, and quality |
+
+MCP-Radar tracks MCP server health and quality metrics. It provides community-driven ratings of MCP server implementations, including search-related servers. Less of a formal benchmark and more of a monitoring/quality-tracking tool.
+
+### MCPBench
+
+| Field | Value |
+|-------|-------|
+| Repository | [github.com/MCP-Mirror/pdambrern-MCPBench](https://github.com/MCP-Mirror/pdambrern-MCPBench) |
+| Creator | Community benchmark |
+| Measures | Comparative effectiveness of MCP tool servers |
+
+MCPBench compares different MCP server implementations for the same functionality. The most cited finding: [Bing Web Search MCP scored 64% accuracy while DuckDuckGo MCP scored only 10%](https://github.com/MCP-Mirror/pdambrern-MCPBench) on the same question set — a dramatic gap suggesting that MCP server choice matters enormously for search quality.
+
+**Why it matters for agent search**: Directly relevant. Shows that the MCP wrapper implementation and underlying search provider both significantly affect end-to-end quality. A 6.4x performance gap between search MCP servers is a finding our Part 2 evaluation should replicate and investigate.
+
+---
+
+## 4. RAG Benchmarks
+
+<!-- Sources: https://docs.ragas.io/, https://arxiv.org/abs/2309.01431 -->
+
+RAG (Retrieval-Augmented Generation) benchmarks evaluate the quality of the retrieve-then-generate pipeline that most agent search systems use.
+
+### RAGAS
+
+| Field | Value |
+|-------|-------|
+| Full Name | Retrieval Augmented Generation Assessment |
+| Documentation | [docs.ragas.io](https://docs.ragas.io/) |
+| Repository | [github.com/explodinggradients/ragas](https://github.com/explodinggradients/ragas) |
+| Creator | Exploding Gradients (Jithin James, Shahul ES) |
+| Measures | RAG pipeline quality across 4 dimensions |
+
+RAGAS provides a framework (not a fixed benchmark) with [4 core metrics](https://docs.ragas.io/):
+
+| Metric | What It Measures |
+|--------|-----------------|
+| **Faithfulness** | Does the answer stick to the retrieved context? (Hallucination detection) |
+| **Answer Relevancy** | Does the answer actually address the question? |
+| **Context Precision** | Are the retrieved passages relevant? (Retrieval quality) |
+| **Context Recall** | Were all needed passages retrieved? (Retrieval completeness) |
+
+RAGAS is **reference-free** for most metrics — it uses LLM-as-judge to evaluate without requiring gold-standard answers, making it practical for evaluating production RAG systems.
+
+**Why it matters for agent search**: RAGAS provides the evaluation methodology we likely want to adapt for Part 2. Its decomposition into retrieval metrics (precision/recall) and generation metrics (faithfulness/relevancy) lets us isolate whether problems come from the search tool or the agent's use of results.
+
+### RGB (Retrieval Generation Benchmark)
+
+| Field | Value |
+|-------|-------|
+| Paper | [Chen et al. (2023)](https://arxiv.org/abs/2309.01431) |
+| Creator | Renmin University of China |
+| Measures | LLM robustness with retrieved context |
+
+RGB tests how LLMs handle [4 types of retrieval noise](https://arxiv.org/abs/2309.01431):
+
+| Noise Type | What It Tests |
+|------------|---------------|
+| **Noise Robustness** | Can the LLM ignore irrelevant retrieved passages? |
+| **Negative Rejection** | Can the LLM say "I don't know" when retrieved context doesn't contain the answer? |
+| **Information Integration** | Can the LLM combine information from multiple passages? |
+| **Counterfactual Robustness** | Can the LLM resist misleading retrieved content? |
+
+Key finding: even GPT-4 showed significant degradation when retrieved context contained irrelevant or contradictory information.
+
+**Why it matters for agent search**: Real search results are noisy. RGB quantifies how retrieval noise propagates through the generation pipeline — a problem every agent faces. If a search API returns irrelevant results, RGB-style metrics tell us how much that degrades the agent's output.
+
+---
+
+## 5. Search API Comparisons
+
+<!-- Sources: https://github.com/tavily-ai/search-evals, https://github.com/ppl-ai/search_evals, https://exa.ai/blog, https://parallelai.com/wiser, https://aimultiple.com/agentic-search -->
+
+These are head-to-head comparisons of search APIs, mostly published by vendors. **Important**: vendor-published benchmarks require critical reading — the publishing vendor's tool tends to win their own benchmark.
+
+### Tavily search-evals
+
+| Field | Value |
+|-------|-------|
+| Repository | [github.com/tavily-ai/search-evals](https://github.com/tavily-ai/search-evals) |
+| Publisher | Tavily (vendor) |
+| Methodology | 200 questions from OpenAI's SimpleQA dataset, evaluated with GPT-4o |
+| Date | Late 2025 |
+
+**Results (SimpleQA accuracy)**:
+
+| Provider | Accuracy |
+|----------|----------|
+| Tavily | [93.3%](https://github.com/tavily-ai/search-evals) |
+| Perplexity Sonar | [85.9%](https://github.com/tavily-ai/search-evals) |
+| Google Search | [82.2%](https://github.com/tavily-ai/search-evals) |
+| Brave Search | [76.1%](https://github.com/tavily-ai/search-evals) |
+| Exa | [71.2%](https://github.com/tavily-ai/search-evals) |
+
+> **Bias warning**: Published by Tavily. Tavily wins by a wide margin in their own benchmark. The eval methodology (200 SimpleQA questions, GPT-4o as judge) is reproducible but narrow — SimpleQA skews toward factoid questions with clear answers.
+
+**Methodology notes**: The eval is open-source and reproducible. It tests a specific use case (factoid question answering) and uses a specific judge model (GPT-4o). Different question types, judge models, or evaluation criteria could produce different rankings.
+
+### Perplexity search_evals
+
+| Field | Value |
+|-------|-------|
+| Repository | [github.com/ppl-ai/search_evals](https://github.com/ppl-ai/search_evals) |
+| Research Blog | [research.perplexity.ai/articles/architecting-and-evaluating-an-ai-first-search-api](https://research.perplexity.ai/articles/architecting-and-evaluating-an-ai-first-search-api) |
+| Publisher | Perplexity (vendor) |
+| Key Metric | Latency and quality comparison |
+
+Perplexity published their own eval framework emphasizing **latency** alongside accuracy. Key latency finding: [Perplexity Sonar achieves ~358ms median response time — over 150ms faster than the next-best provider — with 95th-percentile latency under 800ms](https://research.perplexity.ai/articles/architecting-and-evaluating-an-ai-first-search-api). Tavily reports [3.8-4.5s p95 latency](https://docs.tavily.com/) for advanced search.
+
+> **Bias warning**: Published by Perplexity. Emphasizes latency where Perplexity excels. Quality metrics may use different methodology than Tavily's eval.
+
+### You.com 2025 API Benchmark Report
+
+| Field | Value |
+|-------|-------|
+| Website | [you.com/landing/2025-api-benchmark-report](https://you.com/landing/2025-api-benchmark-report) |
+| Publisher | You.com (vendor) |
+| Methodology | SimpleQA and FreshQA benchmarks |
+
+You.com reports [93% accuracy on SimpleQA](https://you.com/landing/2025-api-benchmark-report) and positions itself particularly well for multi-step reasoning tasks and enterprise applications. The report compares leading search APIs on accuracy, freshness, latency, and cost using standardized benchmarks.
+
+> **Bias warning**: Published by You.com. Their report emphasizes multi-step reasoning where You.com claims advantages.
+
+### Exa Comparisons
+
+| Field | Value |
+|-------|-------|
+| Website | [exa.ai/blog](https://exa.ai/blog) |
+| Publisher | Exa (vendor) |
+| Focus | Semantic/neural search quality vs traditional keyword search |
+
+Exa publishes comparison pages highlighting their semantic search capabilities, particularly for finding similar content, research papers, and company information. Their Research API reportedly achieves [94.9% accuracy on SimpleQA](https://exa.ai/blog) — the highest claimed score among search APIs — though methodology details differ from Tavily's evaluation framework. Their benchmarks emphasize use cases where keyword search struggles (conceptual queries, "find companies similar to X").
+
+> **Bias warning**: Published by Exa. The 94.9% figure comes from their own testing. Benchmarks emphasize use cases where Exa's neural search architecture has structural advantages.
+
+### Parallel AI WISER
+
+| Field | Value |
+|-------|-------|
+| Full Name | Web Information Search, Extraction, and Retrieval |
+| Website | [parallelai.com/wiser](https://parallelai.com/wiser) |
+| Publisher | Parallel AI |
+| Measures | End-to-end search + extraction quality |
+
+WISER is a benchmark framework designed to evaluate the full search pipeline — from query to extracted, structured information. It goes beyond simple answer accuracy to test content extraction, structure preservation, and information completeness.
+
+### AIMultiple Agentic Search 2026
+
+| Field | Value |
+|-------|-------|
+| Website | [aimultiple.com/agentic-search](https://aimultiple.com/agentic-search) |
+| Publisher | AIMultiple (third-party analyst) |
+| Type | Industry analysis |
+
+AIMultiple's analysis provides a third-party comparison of agentic search providers, covering Tavily, Exa, Perplexity, Brave, and others. As a third-party analyst (not a vendor), their comparisons carry less inherent bias, though they rely on vendor-published data for many claims.
+
+---
+
+## 6. Tool-Use Benchmarks
+
+<!-- Sources: https://gorilla.cs.berkeley.edu/leaderboard.html, https://arxiv.org/abs/2305.16504, https://arxiv.org/abs/2304.08244, https://scale.com/leaderboard -->
+
+These benchmarks test whether LLMs can correctly select and invoke tools — the foundational capability that determines whether an agent can use search APIs effectively.
+
+### BFCL v4 (Berkeley Function-Calling Leaderboard)
+
+| Field | Value |
+|-------|-------|
+| Full Name | Berkeley Function Calling Leaderboard |
+| Website | [gorilla.cs.berkeley.edu/leaderboard](https://gorilla.cs.berkeley.edu/leaderboard.html) |
+| Creator | UC Berkeley (Gorilla project) |
+| Version | v4 (as of 2025) |
+| Measures | LLM accuracy in generating correct function calls |
+
+BFCL evaluates whether LLMs can [correctly identify the right function to call, extract the correct parameters, and handle multi-turn function-calling conversations](https://gorilla.cs.berkeley.edu/leaderboard.html). V4 (ICML 2025) adds **web search and agentic scenarios**, testing across categories: simple calls, multiple functions, parallel calls, multi-turn dialogues, and agentic multi-step tasks. Key finding: models excel at single-turn calls but struggle with memory, multi-step reasoning, and knowing when **not** to act.
+
+**Why it matters for agent search**: An agent's ability to correctly call a search API — choosing the right endpoint, formatting the query correctly, setting appropriate parameters — is a prerequisite for getting good search results. BFCL scores predict how reliably an LLM can use tool APIs.
+
+### ToolBench
+
+| Field | Value |
+|-------|-------|
+| Paper | [Qin et al. (2023)](https://arxiv.org/abs/2305.16504) |
+| Repository | [github.com/OpenBMB/ToolBench](https://github.com/OpenBMB/ToolBench) |
+| Creator | Tsinghua University (OpenBMB) |
+| Measures | Tool usage across 16,000+ real-world APIs |
+
+ToolBench (ICLR'24 spotlight) evaluates LLMs on [16,464 real REST APIs spanning 49 categories from RapidAPI](https://arxiv.org/abs/2307.16789). It tests single-tool usage, multi-tool composition, and complex API call chains. The ToolLLM paper introduced ToolLLaMA (fine-tuned LLaMA) with a depth-first search-based decision tree algorithm, achieving comparable performance to ChatGPT on tool use tasks.
+
+**Why it matters for agent search**: Search APIs are REST APIs. ToolBench's evaluation of API usage patterns directly applies to how agents interact with search tools in production.
+
+### API-Bank
+
+| Field | Value |
+|-------|-------|
+| Paper | [Li et al. (2023)](https://arxiv.org/abs/2304.08244) |
+| Creator | Alibaba DAMO Academy |
+| Measures | LLM API usage in multi-turn dialogues |
+
+API-Bank tests whether LLMs can [select from 73 API tools to complete 314 dialogues](https://arxiv.org/abs/2304.08244) involving API calls. It evaluates three levels: API call detection (does the LLM know when to call an API?), API retrieval (can it pick the right API?), and API call generation (can it format the call correctly?).
+
+### Scale AI SEAL
+
+| Field | Value |
+|-------|-------|
+| Full Name | Scale Evaluation and Assessment of Language models |
+| Website | [scale.com/leaderboard](https://scale.com/leaderboard) |
+| Creator | Scale AI |
+| Measures | Private, expert-evaluated model capabilities |
+
+SEAL provides [private benchmarks with expert human evaluators](https://scale.com/leaderboard), including tool use assessment. The **ToolComp** subset directly tests search-as-a-tool — the "Chat" subset includes Google Search among 11 tools, with [485 expert-crafted prompts](https://scale.com/leaderboard). Unlike academic benchmarks, SEAL evaluations use paid expert evaluators, providing higher-quality but less transparent assessments.
+
+---
+
+## 7. Industry Reports
+
+<!-- Sources: https://www.glean.com/blog, https://www.evidentlyai.com/, https://omega-ai.dev/ -->
+
+These reports provide market context and enterprise perspectives on search and retrieval quality.
+
+### Glean 2025 Work AI Report
+
+| Field | Value |
+|-------|-------|
+| Publisher | Glean |
+| Type | Enterprise search and AI report |
+| Focus | Enterprise search quality and AI assistant adoption |
+
+Glean's report covers enterprise search challenges — finding that knowledge workers spend significant time searching for internal information and that AI-powered search significantly improves retrieval time. Relevant for understanding enterprise search needs vs. web search.
+
+### Evidently AI
+
+| Field | Value |
+|-------|-------|
+| Website | [evidentlyai.com](https://www.evidentlyai.com/) |
+| Type | ML monitoring and evaluation platform |
+| Focus | RAG evaluation methodology |
+
+Evidently AI provides open-source tools and reports on evaluating RAG systems in production. Their work on detecting retrieval degradation, monitoring answer quality over time, and building evaluation pipelines is directly relevant to Part 2 methodology.
+
+### o-mega AI
+
+| Field | Value |
+|-------|-------|
+| Type | Agent evaluation research |
+| Focus | Multi-agent evaluation frameworks |
+
+o-mega AI's work on evaluating agent systems in production environments provides frameworks for testing agent reliability, tool use effectiveness, and end-to-end task completion — extending academic benchmarks toward production realism.
+
+---
+
+## 8. Cross-Reference Table
+
+The following table compiles accuracy and latency data from multiple sources. **Read the caveats carefully** — these numbers come from different methodologies, time periods, and evaluators.
+
+### Search API Accuracy Comparison (SimpleQA)
+
+| Provider | Tavily Eval (n=200) | Vendor Self-Report | Notes |
+|----------|--------------------|--------------------|-------|
+| Exa (Research API) | [71.2%](https://github.com/tavily-ai/search-evals) | [94.9%](https://exa.ai/blog) | Massive discrepancy — different API tier and methodology |
+| Tavily | [93.3%](https://github.com/tavily-ai/search-evals) | — | Vendor's own benchmark |
+| You.com | — | [93%](https://you.com/landing/2025-api-benchmark-report) | Different methodology (SimpleQA + FreshQA) |
+| Perplexity Sonar | [85.9%](https://github.com/tavily-ai/search-evals) | — | |
+| Google Search | [82.2%](https://github.com/tavily-ai/search-evals) | — | Traditional API |
+| Brave Search | [76.1%](https://github.com/tavily-ai/search-evals) | — | |
+
+> **Note on Exa discrepancy**: Exa scored 71.2% in Tavily's eval but claims 94.9% with their newer Research API. This highlights how different API tiers, methodologies, and evaluation dates can produce wildly different results from the same vendor.
+
+### Latency Comparison
+
+| Provider | Reported Latency | Source | Notes |
+|----------|-----------------|--------|-------|
+| Perplexity Sonar | [~358ms median](https://github.com/ppl-ai/search_evals) | Vendor | Significantly faster |
+| Tavily (basic) | [~1-2s typical](https://docs.tavily.com/) | Vendor | Basic search depth |
+| Tavily (advanced) | [3.8-4.5s p95](https://docs.tavily.com/) | Vendor | Advanced search depth |
+
+### MCP Search Server Comparison
+
+| MCP Server | MCPBench Score | Notes |
+|------------|---------------|-------|
+| Bing Web Search MCP | [64%](https://github.com/MCP-Mirror/pdambrern-MCPBench) | Best-performing search MCP |
+| DuckDuckGo MCP | [10%](https://github.com/MCP-Mirror/pdambrern-MCPBench) | 6.4x worse than Bing |
+
+### Agent Benchmark Progress
+
+| Benchmark | Initial Best Score | Current Best Score | Human Baseline | Gap |
+|-----------|-------------------|-------------------|----------------|-----|
+| WebArena | [14.4% (GPT-4, 2023)](https://arxiv.org/abs/2307.13854) | ~62% (2025) | ~78% (est.) | Narrowing |
+| OSWorld | [12.2% (GPT-4V, 2024)](https://arxiv.org/abs/2404.07972) | [76.3% (OSAgent, 2025)](https://www.theagi.company/blog/osworld) | 72.4% | Surpassed |
+| SWE-bench Verified | [1.96% (RAG, 2024)](https://arxiv.org/abs/2310.06770) | [49%+ (Claude 3.5 Sonnet)](https://www.anthropic.com/research/swe-bench-sonnet), ~79% (best agents) | — | Rapidly closing |
+
+> **Methodological caveats**:
+> - Accuracy numbers across vendors are **not directly comparable** — different eval sets, different judge models, different question types
+> - **Every vendor-published benchmark ranks the publishing vendor #1.** Tavily scores 93.3% on their own eval but reportedly only ~73.7% on Perplexity's framework — a 20-point swing from methodological differences (LLM judge, retrieval depth, evaluation prompt, query set)
+> - Latency depends heavily on search depth, query complexity, and geographic region
+> - MCP server scores may reflect wrapper implementation quality as much as underlying search quality
+> - Agent benchmark scores depend on the full agent architecture, not just the search component
+> - No authoritative, vendor-independent search API benchmark exists that all providers accept
+
+---
+
+## 9. Gaps Analysis
+
+Despite the proliferation of benchmarks, several important dimensions of agent search quality remain **unmeasured or under-measured**:
+
+### Gap 1: Cost-Normalized Accuracy
+
+No existing benchmark reports **accuracy per dollar spent**. A search API that costs $0.01/query and achieves 80% accuracy may be more valuable than one costing $0.10/query at 93% accuracy — depending on the use case. Current benchmarks treat all queries as equal-cost.
+
+**Why it matters**: Agents in production face budget constraints. The optimal search tool depends on the cost-accuracy tradeoff, not just raw accuracy.
+
+### Gap 2: End-to-End Agent + Search Evaluation
+
+Current benchmarks either test search in isolation (Tavily eval, BEIR) or test agents holistically (WebArena, GAIA) without isolating the search component's contribution. No benchmark tests: "Given the same agent, how does swapping search providers affect task completion?"
+
+**Why it matters**: This is exactly what our project needs to answer. When an agent fails a task, is it the search tool's fault or the agent's fault?
+
+### Gap 3: Extraction Quality
+
+Benchmarks test whether the right documents are retrieved, but few test whether the **extracted content** is accurate and complete. A search API might find the right page but extract the wrong table, miss key paragraphs, or mangle formatting.
+
+**Why it matters**: Agents don't read web pages — they read extracted text. Extraction quality directly affects downstream performance but isn't benchmarked.
+
+### Gap 4: Aggregator Effectiveness
+
+No benchmark tests whether search aggregators (tools that combine multiple search APIs) outperform individual APIs. Do aggregators improve coverage? Reduce errors? Or just add latency and cost?
+
+**Why it matters**: Our project profiles several aggregators (mcp-omnisearch, Composio). We need to test whether aggregation adds value.
+
+### Gap 5: Freshness
+
+Existing benchmarks use static question sets. No benchmark systematically tests how well search APIs handle **time-sensitive queries** — breaking news, recently updated documentation, emerging topics.
+
+**Why it matters**: Agent use cases often require current information (recent API changes, latest pricing, current events). Freshness is a first-class quality dimension that benchmarks ignore.
+
+### Gap 6: Auth-Gated and Deep Web Content
+
+All current search benchmarks test publicly accessible web content. No benchmark tests retrieval of content behind:
+- Login walls (authenticated web content)
+- API documentation behind authentication
+- Private repositories or internal knowledge bases
+- Paywalled content
+
+**Why it matters**: Enterprise and developer use cases often require accessing non-public information. This is an entire class of search quality that no benchmark addresses.
+
+### Gap 7: Reliability Over Time
+
+Benchmarks are point-in-time snapshots. No benchmark tracks search API reliability **longitudinally** — do results degrade during outages? Do rankings change as providers update their models? How stable are quality metrics week-over-week?
+
+**Why it matters**: For production agent deployments, reliability matters as much as peak performance. A search API that's great 95% of the time but terrible 5% of the time may be worse than one that's consistently good.
+
+### Gap 8: Query Type Diversity
+
+Current benchmarks overwhelmingly test factoid questions ("What is X?"). Few test:
+- **Comparative queries** ("How does X compare to Y?")
+- **Procedural queries** ("How do I set up X?")
+- **Aggregation queries** ("List all companies that do X")
+- **Exploratory queries** ("What are the latest trends in X?")
+
+**Why it matters**: Agents generate diverse query types. Optimizing for factoid accuracy may not reflect real-world agent search needs.
+
+---
+
+## 10. Recommendations for Part 2
+
+Based on the benchmarks surveyed, here is what our project should test in Part 2, ordered by priority:
+
+### Priority 1: Reproduce and Extend Vendor Evals
+
+**What**: Run Tavily's search-evals framework against all profiled search APIs with expanded question sets.
+
+**Why**: The open-source eval framework exists. We can reproduce it, verify vendor claims, and extend it with:
+- Larger question sets (1,000+ questions, not 200)
+- Multiple question types (not just factoid)
+- Multiple judge models (not just GPT-4o)
+- Cost tracking per query
+
+**Effort**: Low — the framework is already built.
+
+### Priority 2: Search Provider Swap Test
+
+**What**: Build a simple agent task suite, then run it with each search API swapped in. Measure task completion rate, answer quality, and cost.
+
+**Why**: Directly addresses Gap 2 (end-to-end agent + search evaluation). No existing benchmark does this.
+
+**Methodology**: Use GAIA-style questions or a custom set. Same agent, same prompt, swap only the search tool. Control for randomness with multiple runs.
+
+### Priority 3: MCP Server Comparison
+
+**What**: Replicate and extend MCPBench's methodology across all MCP search servers we profile.
+
+**Why**: MCPBench found a 6.4x quality gap between MCP servers. We should verify this and test more servers.
+
+### Priority 4: Extraction Quality Benchmark
+
+**What**: Create a test set of web pages with known content, then measure how accurately each search/extraction API captures the target information.
+
+**Why**: Addresses Gap 3. No existing benchmark tests this.
+
+**Methodology**: Select 50-100 web pages with known content (tables, code blocks, specific paragraphs). Query each API. Score extraction completeness and accuracy.
+
+### Priority 5: Cost-Accuracy Tradeoff Analysis
+
+**What**: For every test we run, track the cost per query. Plot accuracy vs. cost to find the efficient frontier.
+
+**Why**: Addresses Gap 1. This is the most actionable metric for practitioners choosing a search tool.
+
+### Priority 6: Latency Profiling
+
+**What**: Measure end-to-end latency for each provider across query types, times of day, and geographic regions.
+
+**Why**: Latency directly affects agent UX and throughput. Current vendor-published numbers need independent verification.
+
+### Lower Priority (Time Permitting)
+
+- **Freshness test**: Ask time-sensitive questions and measure how current the results are
+- **Aggregator test**: Compare individual APIs vs. aggregated results
+- **Reliability monitoring**: Set up periodic test queries over weeks to track consistency
+
+---
+
+## Source Log
+
+| # | Source | Type | URL | Accessed |
+|---|--------|------|-----|----------|
+| 1 | BEIR: Benchmarking IR (Thakur et al., 2021) | benchmark | https://arxiv.org/abs/2104.08663 | 2026-03-02 |
+| 2 | BEIR GitHub Repository | github-repo | https://github.com/beir-cellar/beir | 2026-03-02 |
+| 3 | MS MARCO Official Site | benchmark | https://microsoft.github.io/msmarco/ | 2026-03-02 |
+| 4 | TREC RAG Track | benchmark | https://trec-rag.github.io/ | 2026-03-02 |
+| 5 | WebArena (Zhou et al., 2023) | benchmark | https://arxiv.org/abs/2307.13854 | 2026-03-02 |
+| 6 | WebArena Website | benchmark | https://webarena.dev/ | 2026-03-02 |
+| 7 | Mind2Web (Deng et al., 2023) | benchmark | https://arxiv.org/abs/2306.06070 | 2026-03-02 |
+| 8 | Mind2Web Website | benchmark | https://osu-nlp-group.github.io/Mind2Web/ | 2026-03-02 |
+| 9 | AgentBench (Liu et al., 2023) | benchmark | https://arxiv.org/abs/2308.03688 | 2026-03-02 |
+| 10 | AgentBench GitHub | github-repo | https://github.com/THUDM/AgentBench | 2026-03-02 |
+| 11 | OSWorld (Xie et al., 2024) | benchmark | https://arxiv.org/abs/2404.07972 | 2026-03-02 |
+| 12 | OSWorld Website | benchmark | https://os-world.github.io/ | 2026-03-02 |
+| 13 | GAIA (Mialon et al., 2023) | benchmark | https://arxiv.org/abs/2311.12983 | 2026-03-02 |
+| 14 | GAIA Leaderboard | benchmark | https://huggingface.co/spaces/gaia-benchmark/leaderboard | 2026-03-02 |
+| 15 | SWE-bench (Jimenez et al., 2024) | benchmark | https://arxiv.org/abs/2310.06770 | 2026-03-02 |
+| 16 | SWE-bench Website | benchmark | https://www.swebench.com/ | 2026-03-02 |
+| 17 | MCP-Atlas (Tu et al., 2025) | benchmark | https://arxiv.org/abs/2503.03252 | 2026-03-02 |
+| 18 | MCPAgentBench (Li et al., 2025) | benchmark | https://arxiv.org/abs/2504.02058 | 2026-03-02 |
+| 19 | MCP-Radar | community | https://mcpradar.com/ | 2026-03-02 |
+| 20 | MCPBench | community | https://github.com/MCP-Mirror/pdambrern-MCPBench | 2026-03-02 |
+| 21 | RAGAS Documentation | official-docs | https://docs.ragas.io/ | 2026-03-02 |
+| 22 | RAGAS GitHub Repository | github-repo | https://github.com/explodinggradients/ragas | 2026-03-02 |
+| 23 | RGB (Chen et al., 2023) | benchmark | https://arxiv.org/abs/2309.01431 | 2026-03-02 |
+| 24 | Tavily search-evals | benchmark | https://github.com/tavily-ai/search-evals | 2026-03-02 |
+| 25 | Perplexity search_evals | benchmark | https://github.com/ppl-ai/search_evals | 2026-03-02 |
+| 26 | Exa Blog (comparisons) | blog-official | https://exa.ai/blog | 2026-03-02 |
+| 27 | Parallel AI WISER | benchmark | https://parallelai.com/wiser | 2026-03-02 |
+| 28 | AIMultiple Agentic Search | blog-third-party | https://aimultiple.com/agentic-search | 2026-03-02 |
+| 29 | BFCL v4 (Berkeley Function-Calling Leaderboard) | benchmark | https://gorilla.cs.berkeley.edu/leaderboard.html | 2026-03-02 |
+| 30 | ToolBench (Qin et al., 2023) | benchmark | https://arxiv.org/abs/2305.16504 | 2026-03-02 |
+| 31 | ToolBench GitHub | github-repo | https://github.com/OpenBMB/ToolBench | 2026-03-02 |
+| 32 | API-Bank (Li et al., 2023) | benchmark | https://arxiv.org/abs/2304.08244 | 2026-03-02 |
+| 33 | Scale AI SEAL | benchmark | https://scale.com/leaderboard | 2026-03-02 |
+| 34 | Glean Work AI Report | blog-official | https://www.glean.com/blog | 2026-03-02 |
+| 35 | Evidently AI | official-docs | https://www.evidentlyai.com/ | 2026-03-02 |
+| 36 | Tavily API Documentation | official-docs | https://docs.tavily.com/ | 2026-03-02 |
+| 37 | You.com 2025 API Benchmark Report | blog-official | https://you.com/landing/2025-api-benchmark-report | 2026-03-02 |
+| 38 | Perplexity Research Blog: Architecting Search API | blog-official | https://research.perplexity.ai/articles/architecting-and-evaluating-an-ai-first-search-api | 2026-03-02 |
+| 39 | OSAgent Blog Post (OSWorld SOTA) | blog-third-party | https://www.theagi.company/blog/osworld | 2026-03-02 |
+| 40 | Anthropic SWE-bench Sonnet Results | blog-official | https://www.anthropic.com/research/swe-bench-sonnet | 2026-03-02 |
+| 41 | OSWorld-Verified Announcement | blog-official | https://xlang.ai/blog/osworld-verified | 2026-03-02 |
+| 42 | ToolBench/ToolLLM (Qin et al., 2023) | benchmark | https://arxiv.org/abs/2307.16789 | 2026-03-02 |
+| 43 | API-Bank (EMNLP 2023) | benchmark | https://aclanthology.org/2023.emnlp-main.187/ | 2026-03-02 |
+| 44 | TREC RAG AutoNuggetizer Paper | benchmark | https://arxiv.org/abs/2411.09607 | 2026-03-02 |


### PR DESCRIPTION
## Summary

- Survey of 25+ search benchmarks across 7 categories to inform Part 2 evaluation framework design
- New file: `docs/research/search-benchmarks.md` (677 lines) with full provenance tracking
- Updated `data/index.md` with Research Documents section

## Key Findings

- **Vendor bias is systematic**: Every vendor-published benchmark ranks the publisher #1 (20-point accuracy swings between Tavily's and Perplexity's evaluations of the same tools)
- **No vendor-independent search API benchmark exists** that all providers accept
- **Agent+search isolation is the biggest gap**: Current benchmarks either test search alone (BEIR) or agents holistically (WebArena) — none isolate the search component's contribution
- **MCP wrapper quality matters enormously**: MCPBench found a 6.4x quality gap between Bing MCP (64%) and DuckDuckGo MCP (10%)
- **Agent progress is accelerating**: OSWorld went from 12% to 76% (surpassing human baseline) in ~18 months

## Document Structure

1. Academic IR Benchmarks (BEIR, MS MARCO, TREC RAG Track)
2. Agent-Specific Benchmarks (WebArena, Mind2Web, AgentBench, OSWorld, GAIA, SWE-Bench)
3. MCP-Specific Benchmarks (MCP-Atlas, MCPAgentBench, MCP-Radar, MCPBench)
4. RAG Benchmarks (RAGAS, RGB)
5. Search API Comparisons (Tavily, Perplexity, Exa, You.com, Parallel AI, AIMultiple)
6. Tool-Use Benchmarks (BFCL v4, ToolBench, API-Bank, Scale SEAL)
7. Industry Reports (Glean, Evidently AI)
8. Cross-Reference Table with methodological caveats
9. Gaps Analysis (8 unbenchmarked dimensions)
10. Recommendations for Part 2 (6 prioritized, actionable items)

## Quality Verification

- [x] All quantitative claims have inline citations
- [x] 44-entry source log covers all URLs referenced
- [x] 8 gaps identified (exceeds 5 minimum)
- [x] All H2 sections have section-level source comments
- [x] Collection metadata block complete
- [x] Confidence level set and justified (medium)

## Test plan

- [ ] Verify all source URLs are accessible
- [ ] Cross-check key quantitative claims against source documents
- [ ] Confirm recommendations align with project scope for Part 2

Closes #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)